### PR TITLE
refactored RestoreCommand a bit

### DIFF
--- a/src/NuGet.Client/ManagedCodeConventions.cs
+++ b/src/NuGet.Client/ManagedCodeConventions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Threading.Tasks;
 using NuGet.ContentModel;
 using NuGet.Frameworks;
 using NuGet.RuntimeModel;

--- a/src/NuGet.Client/project.json
+++ b/src/NuGet.Client/project.json
@@ -4,6 +4,8 @@
     "NuGet.Versioning": "3.0.0-*",
     "NuGet.Packaging": "3.0.0-*",
     "NuGet.Repositories": "3.0.0-*",
+    "NuGet.RuntimeModel": "3.0.0-*",
+    "NuGet.ContentModel": "3.0.0-*",
     "NuGet.Common": { "version": "3.0.0-*", "type": "build" }
   },
 

--- a/src/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -21,11 +21,11 @@ namespace NuGet.DependencyResolver
             _context = context;
         }
 
-        public Task<GraphNode<RemoteResolveResult>> Walk(LibraryRange library, NuGetFramework framework, string runtimeName, RuntimeGraph runtimeGraph)
+        public Task<GraphNode<RemoteResolveResult>> Walk(LibraryRange library, NuGetFramework framework, string runtimeIdentifier, RuntimeGraph runtimeGraph)
         {
             var cache = new Dictionary<LibraryRange, Task<GraphItem<RemoteResolveResult>>>();
 
-            return CreateGraphNode(cache, library, framework, runtimeName, runtimeGraph, _ => true);
+            return CreateGraphNode(cache, library, framework, runtimeIdentifier, runtimeGraph, _ => true);
         }
 
         private async Task<GraphNode<RemoteResolveResult>> CreateGraphNode(Dictionary<LibraryRange, Task<GraphItem<RemoteResolveResult>>> cache, LibraryRange libraryRange, NuGetFramework framework, string runtimeName, RuntimeGraph runtimeGraph, Func<string, bool> predicate)

--- a/src/NuGet.DependencyResolver.Core/Remote/RemoteMatch.cs
+++ b/src/NuGet.DependencyResolver.Core/Remote/RemoteMatch.cs
@@ -4,10 +4,25 @@ using NuGet.LibraryModel;
 
 namespace NuGet.DependencyResolver
 {
-    public class RemoteMatch
+    public class RemoteMatch : IEquatable<RemoteMatch>
     {
         public IRemoteDependencyProvider Provider { get; set; }
         public LibraryIdentity Library { get; set; }
         public string Path { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as RemoteMatch);
+        }
+
+        public bool Equals(RemoteMatch other)
+        {
+            return other != null && Library.Equals(other.Library);
+        }
+
+        public override int GetHashCode()
+        {
+            return Library.GetHashCode();
+        }
     }
 }

--- a/src/NuGet.RuntimeModel/JsonRuntimeFormat.cs
+++ b/src/NuGet.RuntimeModel/JsonRuntimeFormat.cs
@@ -53,12 +53,8 @@ namespace NuGet.RuntimeModel
 
         public static RuntimeGraph ReadRuntimeGraph(JToken json)
         {
-            var graph = new RuntimeGraph();
-            foreach (var runtimeSpec in EachProperty(json["runtimes"]).Select(ReadRuntimeDescription))
-            {
-                graph.Runtimes.Add(runtimeSpec.RuntimeIdentifier, runtimeSpec);
-            }
-            return graph;
+            return new RuntimeGraph(
+                EachProperty(json["runtimes"]).Select(ReadRuntimeDescription));
         }
 
         private static void WriteRuntimeGraph(JObject json, RuntimeGraph runtimeGraph)

--- a/src/NuGet.RuntimeModel/RuntimeGraph.cs
+++ b/src/NuGet.RuntimeModel/RuntimeGraph.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -7,16 +8,20 @@ namespace NuGet.RuntimeModel
 {
     public class RuntimeGraph : IEquatable<RuntimeGraph>
     {
-        public IDictionary<string, RuntimeDescription> Runtimes { get; }
+        public static readonly string RuntimeGraphFileName = "runtime.json";
 
-        public RuntimeGraph()
+        public static readonly RuntimeGraph Empty = new RuntimeGraph();
+
+        public IReadOnlyDictionary<string, RuntimeDescription> Runtimes { get; }
+
+        private RuntimeGraph()
         {
-            Runtimes = new Dictionary<string, RuntimeDescription>();
+            Runtimes = new ReadOnlyDictionary<string, RuntimeDescription>(new Dictionary<string, RuntimeDescription>());
         }
 
         public RuntimeGraph(IEnumerable<RuntimeDescription> runtimes)
         {
-            Runtimes = runtimes.ToDictionary(r => r.RuntimeIdentifier);
+            Runtimes = new ReadOnlyDictionary<string, RuntimeDescription>(runtimes.ToDictionary(r => r.RuntimeIdentifier));
         }
 
         public RuntimeGraph Clone() => new RuntimeGraph(Runtimes.Values.Select(r => r.Clone()));

--- a/src/NuGet.Strawman.Commands/RestoreCommand.cs
+++ b/src/NuGet.Strawman.Commands/RestoreCommand.cs
@@ -37,6 +37,7 @@ namespace NuGet.Strawman.Commands
             if (request.Project.TargetFrameworks.Count == 0)
             {
                 _log.LogError("The project does not specify any target frameworks!");
+                return new RestoreResult(success: false, restoreGraphs: Enumerable.Empty<RestoreTargetGraph>());
             }
 
             var projectLockFilePath = Path.Combine(request.Project.BaseDirectory, LockFileFormat.LockFileName);
@@ -75,60 +76,64 @@ namespace NuGet.Strawman.Commands
 
             // Resolve dependency graphs
             var frameworks = request.Project.TargetFrameworks.Select(f => f.FrameworkName).ToList();
-            List<RestoreTargetGraph> graphs = await WalkDependencies(
-                projectRange,
-                frameworks,
-                remoteWalker);
+            var graphs = new List<RestoreTargetGraph>();
+            foreach (var framework in frameworks)
+            {
+                graphs.Add(await WalkDependencies(projectRange, framework, remoteWalker, context));
+            }
 
-            if (!ResolveConflicts(graphs))
+            if (graphs.Any(g => g.InConflict))
             {
                 _log.LogError("Failed to resolve conflicts");
                 return new RestoreResult(success: false, restoreGraphs: graphs);
             }
 
+            // Install the runtime-agnostic packages
+            var allInstalledPackages = new HashSet<LibraryIdentity>();
+            var localRepository = new NuGetv3LocalRepository(request.PackagesDirectory, checkPackageIdCase: false);
+            await InstallPackages(graphs, request.PackagesDirectory, allInstalledPackages);
+
             // Resolve runtime dependencies
+            var runtimeGraphs = new List<RestoreTargetGraph>();
             if (request.Project.RuntimeGraph.Runtimes.Count > 0)
             {
-                var runtimeGraphs = await WalkRuntimeDependencies(projectRange, graphs, frameworks, request.Project.RuntimeGraph, remoteWalker);
-                var resolved = ResolveConflicts(runtimeGraphs);
+                foreach (var graph in graphs)
+                {
+                    var runtimeSpecificGraphs = await WalkRuntimeDependencies(projectRange, graph, request.Project.RuntimeGraph, remoteWalker, context, localRepository);
+                    runtimeGraphs.AddRange(runtimeSpecificGraphs);
+                }
                 graphs.AddRange(runtimeGraphs);
-                if(!resolved)
+                if (runtimeGraphs.Any(g => g.InConflict))
                 {
                     _log.LogError("Failed to resolve conflicts");
                     return new RestoreResult(success: false, restoreGraphs: graphs);
                 }
+
+                // Install runtime-specific packages
+                await InstallPackages(runtimeGraphs, request.PackagesDirectory, allInstalledPackages);
             }
             else
             {
                 _log.LogVerbose("Skipping runtime dependency walk, no runtimes defined in project.json");
             }
 
-            // Flatten dependency graphs
-            var toInstall = new List<RemoteMatch>();
-            var flattened = new List<GraphItem<RemoteResolveResult>>();
-            bool success = FlattenDependencyGraph(graphs, context, toInstall, flattened);
-
-            // Install packages into the local package directory
-            await InstallPackages(toInstall, request.PackagesDirectory);
-
             // Build the lock file
-            if (success)
-            {
-                var repository = new NuGetv3LocalRepository(request.PackagesDirectory, checkPackageIdCase: false);
-                var lockFile = CreateLockFile(request.Project, graphs, flattened, repository);
-                var lockFileFormat = new LockFileFormat();
-                lockFileFormat.Write(projectLockFilePath, lockFile);
-            }
-            return new RestoreResult(success, graphs);
+            var repository = new NuGetv3LocalRepository(request.PackagesDirectory, checkPackageIdCase: false);
+            var lockFile = CreateLockFile(request.Project, graphs, repository);
+            var lockFileFormat = new LockFileFormat();
+            lockFileFormat.Write(projectLockFilePath, lockFile);
+
+            return new RestoreResult(true, graphs, lockFile);
         }
 
-        private LockFile CreateLockFile(PackageSpec project, List<RestoreTargetGraph> targetGraphs, List<GraphItem<RemoteResolveResult>> flattened, NuGetv3LocalRepository repository)
+
+        private LockFile CreateLockFile(PackageSpec project, List<RestoreTargetGraph> targetGraphs, NuGetv3LocalRepository repository)
         {
             var lockFile = new LockFile();
 
             using (var sha512 = SHA512.Create())
             {
-                foreach (var item in flattened.OrderBy(x => x.Data.Match.Library))
+                foreach (var item in targetGraphs.SelectMany(g => g.Flattened).Distinct().OrderBy(x => x.Data.Match.Library))
                 {
                     var library = item.Data.Match.Library;
                     var packageInfo = repository.FindPackagesById(library.Name)
@@ -167,7 +172,7 @@ namespace NuGet.Strawman.Commands
                 target.TargetFramework = targetGraph.Framework;
                 target.RuntimeIdentifier = targetGraph.RuntimeIdentifier;
 
-                foreach (var library in targetGraph.Libraries.OrderBy(x => x))
+                foreach (var library in targetGraph.Flattened.Select(g => g.Key).OrderBy(x => x))
                 {
                     var packageInfo = repository.FindPackagesById(library.Name)
                         .FirstOrDefault(p => p.Version == library.Version);
@@ -301,98 +306,79 @@ namespace NuGet.Strawman.Commands
             return lockFileLib;
         }
 
-        private async Task<List<RestoreTargetGraph>> WalkRuntimeDependencies(LibraryRange projectRange, IEnumerable<RestoreTargetGraph> graphs, IEnumerable<NuGetFramework> frameworks, RuntimeGraph projectRuntimes, RemoteDependencyWalker walker)
+        private Task<RestoreTargetGraph> WalkDependencies(LibraryRange projectRange, NuGetFramework framework, RemoteDependencyWalker walker, RemoteWalkContext context)
         {
-            var restoreGraphs = new List<RestoreTargetGraph>();
-            foreach (var graph in graphs)
-            {
-                // Load runtime specs
-                _log.LogVerbose("Scanning packages for runtime.json files...");
-                var runtimeFilePackages = new List<LibraryIdentity>();
-                var runtimeFileTasks = new List<Task<RuntimeGraph>>();
-                graph.Graph.ForEach(node =>
-                {
-                    var match = node?.Item?.Data?.Match;
-                    if (match == null) { return; }
-                    runtimeFilePackages.Add(match.Library);
-                    runtimeFileTasks.Add(match.Provider.GetRuntimeGraph(node.Item.Data.Match, graph.Framework));
-                });
-
-                var libraryRuntimeFiles = await Task.WhenAll(runtimeFileTasks);
-
-                // Build the complete runtime graph
-                var runtimeGraph = projectRuntimes;
-                foreach (var runtimePair in libraryRuntimeFiles.Zip(runtimeFilePackages, Tuple.Create).Where(file => file.Item1 != null))
-                {
-                    _log.LogVerbose($"Merging in runtimes defined in {runtimePair.Item2}");
-                    runtimeGraph = RuntimeGraph.Merge(runtimeGraph, runtimePair.Item1);
-                }
-
-                foreach (var runtimeName in projectRuntimes.Runtimes.Keys)
-                {
-                    // Walk dependencies for the runtime
-                    _log.LogInformation($"Restoring packages for {graph.Framework} on {runtimeName}");
-                    restoreGraphs.Add(new RestoreTargetGraph(
-                        runtimeName,
-                        runtimeGraph,
-                        graph.Framework,
-                        await walker.Walk(
-                            projectRange,
-                            graph.Framework,
-                            runtimeName,
-                            runtimeGraph)));
-                }
-            }
-            return restoreGraphs;
+            return WalkDependencies(projectRange, framework, null, RuntimeGraph.Empty, walker, context);
         }
 
-        private bool FlattenDependencyGraph(List<RestoreTargetGraph> graphs, RemoteWalkContext context, IList<RemoteMatch> toInstall, IList<GraphItem<RemoteResolveResult>> flattened)
+        private async Task<RestoreTargetGraph> WalkDependencies(LibraryRange projectRange, NuGetFramework framework, string runtimeIdentifier, RuntimeGraph runtimeGraph, RemoteDependencyWalker walker, RemoteWalkContext context)
         {
-            bool success = true;
-            foreach (var graph in graphs)
-            {
-                // REVIEW: This is a bit hacky but I want to, in a single loop, generate some flattened lists WITHIN each graph and flattened lists ACROSS ALL graphs
-                success &= graph.Flatten(context, toInstall, flattened, _loggerFactory);
-            }
-            return success;
+            _log.LogInformation($"Restoring packages for {framework}");
+            var graph = await walker.Walk(
+                projectRange,
+                framework,
+                runtimeIdentifier,
+                runtimeGraph);
+
+            // Resolve conflicts
+            _log.LogVerbose($"Resolving Conflicts for {framework}");
+            bool inConflict = !graph.TryResolveConflicts();
+
+            // Flatten and create the RestoreTargetGraph to hold the packages
+            return RestoreTargetGraph.Create(inConflict, framework, runtimeIdentifier, runtimeGraph, graph, context, _loggerFactory);
         }
 
-        private bool ResolveConflicts(List<RestoreTargetGraph> graphs)
+        private async Task<List<RestoreTargetGraph>> WalkRuntimeDependencies(LibraryRange projectRange, RestoreTargetGraph graph, RuntimeGraph projectRuntimeGraph, RemoteDependencyWalker walker, RemoteWalkContext context, NuGetv3LocalRepository localRepository)
         {
-            foreach (var graph in graphs)
+            // Load runtime specs
+            _log.LogVerbose("Scanning packages for runtime.json files...");
+            var runtimeGraph = projectRuntimeGraph;
+            graph.Graph.ForEach(node =>
             {
-                string runtimeStr = string.IsNullOrEmpty(graph.RuntimeIdentifier) ? string.Empty : $" on {graph.RuntimeIdentifier}";
-                _log.LogVerbose($"Resolving Conflicts for {graph.Framework}{runtimeStr}");
-                if (!graph.Graph.TryResolveConflicts())
+                var match = node?.Item?.Data?.Match;
+                if (match == null) { return; }
+
+                // Locate the package in the local repository
+                var package = localRepository.FindPackagesById(match.Library.Name).FirstOrDefault(p => p.Version == match.Library.Version);
+                if(package != null)
                 {
-                    return false;
+                    var nextGraph = LoadRuntimeGraph(package);
+                    if (nextGraph != null)
+                    {
+                        _log.LogVerbose($"Merging in runtimes defined in {match.Library}");
+                        runtimeGraph = RuntimeGraph.Merge(runtimeGraph, nextGraph);
+                    }
+                }
+            });
+
+            var resultGraphs = new List<RestoreTargetGraph>();
+            foreach (var runtimeName in projectRuntimeGraph.Runtimes.Keys)
+            {
+                _log.LogInformation($"Restoring packages for {graph.Framework} on {runtimeName}");
+                resultGraphs.Add(await WalkDependencies(projectRange, graph.Framework, runtimeName, runtimeGraph, walker, context));
+            }
+            return resultGraphs;
+        }
+
+        private RuntimeGraph LoadRuntimeGraph(LocalPackageInfo package)
+        {
+            var runtimeGraphFile = Path.Combine(package.ExpandedPath, RuntimeGraph.RuntimeGraphFileName);
+            if (File.Exists(runtimeGraphFile))
+            {
+                using (var stream = new FileStream(runtimeGraphFile, FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                    return JsonRuntimeFormat.ReadRuntimeGraph(stream);
                 }
             }
-            return true;
+            return null;
         }
 
-        private async Task<List<RestoreTargetGraph>> WalkDependencies(LibraryRange projectRange, IEnumerable<NuGetFramework> frameworks, RemoteDependencyWalker walker)
+        private async Task InstallPackages(IEnumerable<RestoreTargetGraph> graphs, string packagesDirectory, HashSet<LibraryIdentity> allInstalledPackages)
         {
-            var graphs = new List<RestoreTargetGraph>();
-            foreach (var framework in frameworks)
+            foreach (var packageToInstall in graphs.SelectMany(g => g.Install.Where(match => allInstalledPackages.Add(match.Library))))
             {
-                _log.LogInformation($"Restoring packages for {framework}");
-                var graph = await walker.Walk(
-                    projectRange,
-                    framework,
-                    runtimeName: null,
-                    runtimeGraph: null);
-                graphs.Add(new RestoreTargetGraph(string.Empty, null, framework, graph));
-            }
-
-            return graphs;
-        }
-
-        private async Task InstallPackages(List<RemoteMatch> installItems, string packagesDirectory)
-        {
-            foreach (var installItem in installItems)
-            {
-                await InstallPackage(installItem, packagesDirectory);
+                // TODO: Parallel!
+                await InstallPackage(packageToInstall, packagesDirectory);
             }
         }
 

--- a/src/NuGet.Strawman.Commands/RestoreGraph.cs
+++ b/src/NuGet.Strawman.Commands/RestoreGraph.cs
@@ -12,35 +12,65 @@ namespace NuGet.Strawman.Commands
 {
     public class RestoreTargetGraph
     {
+        /// <summary>
+        /// Gets the runtime identifier used during the restore operation on this graph
+        /// </summary>
         public string RuntimeIdentifier { get; }
-        public ManagedCodeConventions Conventions { get; }
-        public RuntimeGraph RuntimeGraph { get; }
+
+        /// <summary>
+        /// Gets the <see cref="NuGetFramework"/> used during the restore operation on this graph
+        /// </summary>
         public NuGetFramework Framework { get; }
+
+        /// <summary>
+        /// Gets the <see cref="ManagedCodeConventions"/> used to resolve assets from packages in this graph
+        /// </summary>
+        public ManagedCodeConventions Conventions { get; }
+
+        /// <summary>
+        /// Gets the <see cref="RuntimeGraph"/> that defines runtimes and their relationships for this graph
+        /// </summary>
+        public RuntimeGraph RuntimeGraph { get; }
+
+        /// <summary>
+        /// Gets the resolved dependency graph
+        /// </summary>
         public GraphNode<RemoteResolveResult> Graph { get; }
 
-        public HashSet<LibraryIdentity> Libraries { get; private set; }
-        public HashSet<LibraryRange> Unresolved { get; private set; }
+        public ISet<RemoteMatch> Install { get; }
+        public ISet<GraphItem<RemoteResolveResult>> Flattened { get; }
+        public ISet<LibraryRange> Unresolved { get; }
+        public bool InConflict { get; }
 
-        public RestoreTargetGraph(string runtimeIdentifier, RuntimeGraph runtimeGraph, NuGetFramework framework, GraphNode<RemoteResolveResult> graph)
+        private RestoreTargetGraph(bool inConflict, NuGetFramework framework, string runtimeIdentifier, RuntimeGraph runtimeGraph, GraphNode<RemoteResolveResult> graph, ISet<RemoteMatch> install, ISet<GraphItem<RemoteResolveResult>> flattened, ISet<LibraryRange> unresolved)
         {
+            InConflict = inConflict;
             RuntimeIdentifier = runtimeIdentifier;
             RuntimeGraph = runtimeGraph;
             Framework = framework;
             Graph = graph;
 
             Conventions = new ManagedCodeConventions(runtimeGraph);
+
+            Install = install;
+            Flattened = flattened;
+            Unresolved = unresolved;
         }
 
-        public bool Flatten(RemoteWalkContext context, IList<RemoteMatch> toInstall, IList<GraphItem<RemoteResolveResult>> flattened, ILoggerFactory loggerFactory)
+        public static RestoreTargetGraph Create(bool inConflict, NuGetFramework framework, GraphNode<RemoteResolveResult> graph, RemoteWalkContext context, ILoggerFactory loggerFactory)
+        {
+            return Create(inConflict, framework, null, RuntimeGraph.Empty, graph, context, loggerFactory);
+        }
+
+        public static RestoreTargetGraph Create(bool inConflict, NuGetFramework framework, string runtimeIdentifier, RuntimeGraph runtimeGraph, GraphNode<RemoteResolveResult> graph, RemoteWalkContext context, ILoggerFactory loggerFactory)
         {
             var log = loggerFactory.CreateLogger<RestoreTargetGraph>();
 
-            var libraries = new HashSet<LibraryIdentity>();
+            var install = new HashSet<RemoteMatch>();
+            var flattened = new HashSet<GraphItem<RemoteResolveResult>>();
             var unresolved = new HashSet<LibraryRange>();
 
-            bool success = true;
-
-            Graph.ForEach(node =>
+            graph.ForEach(node =>
             {
                 if (node == null || node.Key == null || node.Disposition == Disposition.Rejected)
                 {
@@ -50,14 +80,9 @@ namespace NuGet.Strawman.Commands
                 if (node.Item == null || node.Item.Data.Match == null)
                 {
                     if (node.Key.TypeConstraint != LibraryTypes.Reference &&
-                        node.Key.VersionRange != null &&
-                        unresolved.Add(node.Key))
+                        node.Key.VersionRange != null)
                     {
-                        var errorMessage = string.Format("Unable to locate {0} {1}",
-                            node.Key.Name,
-                            node.Key.VersionRange);
-                        log.LogError(errorMessage);
-                        success = false;
+                        unresolved.Add(node.Key);
                     }
 
                     return;
@@ -69,27 +94,25 @@ namespace NuGet.Strawman.Commands
                     node.Item.Data.Match.Library.Name = node.Key.Name;
                 }
 
+                // If the package came from a remote library provider, it needs to be installed locally
                 var isRemote = context.RemoteLibraryProviders.Contains(node.Item.Data.Match.Provider);
-                var isAdded = toInstall.Any(item => item.Library == node.Item.Data.Match.Library);
-
-                if (!isAdded && isRemote)
+                if (isRemote)
                 {
-                    toInstall.Add(node.Item.Data.Match);
+                    install.Add(node.Item.Data.Match);
                 }
 
-                var isGraphItem = flattened.Any(item => item.Data.Match.Library == node.Item.Data.Match.Library);
-                if (!isGraphItem)
-                {
-                    flattened.Add(node.Item);
-                }
-
-                libraries.Add(node.Item.Key);
+                flattened.Add(node.Item);
             });
 
-            Libraries = libraries;
-            Unresolved = unresolved;
-
-            return success;
+            return new RestoreTargetGraph(
+                inConflict,
+                framework,
+                runtimeIdentifier,
+                runtimeGraph,
+                graph,
+                install,
+                flattened,
+                unresolved);
         }
     }
 }

--- a/src/NuGet.Strawman.Commands/RestoreResult.cs
+++ b/src/NuGet.Strawman.Commands/RestoreResult.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using NuGet.LibraryModel;
+using NuGet.ProjectModel;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace NuGet.Strawman.Commands
 {
@@ -11,10 +14,48 @@ namespace NuGet.Strawman.Commands
         /// </summary>
         public IEnumerable<RestoreTargetGraph> RestoreGraphs { get; }
 
+        /// <summary>
+        /// Gets the lock file that was generated during the restore or, in the case of a locked lock file,
+        /// was used to determine the packages to install during the restore.
+        /// </summary>
+        /// <remarks>
+        /// May be null if the restore did not complete successfully
+        /// </remarks>
+        public LockFile LockFile { get; }
+
         public RestoreResult(bool success, IEnumerable<RestoreTargetGraph> restoreGraphs)
+            : this(success, restoreGraphs, lockfile: null)
+        { }
+
+        public RestoreResult(bool success, IEnumerable<RestoreTargetGraph> restoreGraphs, LockFile lockfile)
         {
             Success = success;
             RestoreGraphs = restoreGraphs;
+            LockFile = lockfile;
+        }
+
+        /// <summary>
+        /// Calculates the complete set of all packages installed by this operation
+        /// </summary>
+        /// <remarks>
+        /// This requires quite a bit of iterating over the graph so the result should be cached
+        /// </remarks>
+        /// <returns>A set of libraries that were installed by this operation</returns>
+        public ISet<LibraryIdentity> GetAllInstalled()
+        {
+            return new HashSet<LibraryIdentity>(RestoreGraphs.Where(g => !g.InConflict).SelectMany(g => g.Install).Distinct().Select(m => m.Library));
+        }
+
+        /// <summary>
+        /// Calculates the complete set of all unresolved dependencies for this operation
+        /// </summary>
+        /// <remarks>
+        /// This requires quite a bit of iterating over the graph so the result should be cached
+        /// </remarks>
+        /// <returns>A set of dependencies that were unable to be resolved by this operation</returns>
+        public ISet<LibraryRange> GetAllUnresolved()
+        {
+            return new HashSet<LibraryRange>(RestoreGraphs.SelectMany(g => g.Unresolved).Distinct());
         }
     }
 }

--- a/test/NuGet.RuntimeModel.Test/JsonRuntimeFormatTests.cs
+++ b/test/NuGet.RuntimeModel.Test/JsonRuntimeFormatTests.cs
@@ -12,7 +12,7 @@ namespace NuGet.RuntimeModel.Test
         [InlineData("{\"runtimes\":{}}")]
         public void CanParseEmptyRuntimeJsons(string content)
         {
-            Assert.Equal(new RuntimeGraph(), ParseRuntimeJsonString(content));
+            Assert.Equal(RuntimeGraph.Empty, ParseRuntimeJsonString(content));
         }
 
         [Fact]

--- a/test/NuGet.RuntimeModel.Test/RuntimeGraphTests.cs
+++ b/test/NuGet.RuntimeModel.Test/RuntimeGraphTests.cs
@@ -16,7 +16,7 @@ namespace NuGet.RuntimeModel.Test
                 new RuntimeDescription("any"),
                 new RuntimeDescription("win8", new[] { "any" })
                 });
-            var newGraph = RuntimeGraph.Merge(graph, new RuntimeGraph());
+            var newGraph = RuntimeGraph.Merge(graph, RuntimeGraph.Empty);
             Assert.Equal(new RuntimeGraph(new[] {
                 new RuntimeDescription("any"),
                 new RuntimeDescription("win8", new[] { "any" })


### PR DESCRIPTION
There is only one functional change in this change, the rest is just some refactoring. The main change is in the order of operations.

**BEFORE THIS CHANGE**:
1. Walk the runtime-agnostic graphs
2. Resolve conflicts
3. Scan the packages for `runtime.json` files by cracking open nupkgs
4. Walk the runtime-specific graphs
5. Resolve conflicts
6. Install all packages to the local packages directory in one pass

**AFTER THIS CHANGE**:
1. Walk the runtime-agnostic graphs
2. Resolve conflicts
3. Install all runtime-agnostic packages to the local packages directory (**NEW**)
4. Scan the packages for `runtime.json` files by looking at the extracted files from step 3
5. Walk the runtime-specific graphs
6. Resolve conflicts
7. Install all runtime-specific packages to the local packages directory in one pass (**NEW**)

/cc @pranavkm @davidfowl @emgarten 
