### PR TITLE
add support for lib/{assembly} and <references> node in nuspec

### DIFF
--- a/src/NuGet.Client/ManagedCodeConventions.cs
+++ b/src/NuGet.Client/ManagedCodeConventions.cs
@@ -25,9 +25,9 @@ namespace NuGet.Client
 
         private RuntimeGraph _runtimeGraph;
 
-        public CriteriaSet Criteria { get; }
+        public ManagedCodeCriteria Criteria { get; }
         public IReadOnlyDictionary<string, ContentPropertyDefinition> Properties { get; }
-        public PatternSet Patterns { get; }
+        public ManagedCodePatterns Patterns { get; }
 
         public ManagedCodeConventions(RuntimeGraph runtimeGraph)
         {
@@ -44,8 +44,8 @@ namespace NuGet.Client
 
             Properties = new ReadOnlyDictionary<string, ContentPropertyDefinition>(props);
 
-            Criteria = new CriteriaSet(this);
-            Patterns = new PatternSet(this);
+            Criteria = new ManagedCodeCriteria(this);
+            Patterns = new ManagedCodePatterns(this);
         }
 
         private bool RuntimeIdentifier_CompatibilityTest(object criteria, object available)
@@ -120,11 +120,11 @@ namespace NuGet.Client
                                Math.Max(version.Revision, 0));
         }
 
-        public class CriteriaSet
+        public class ManagedCodeCriteria
         {
             private ManagedCodeConventions _conventions;
 
-            internal CriteriaSet(ManagedCodeConventions conventions)
+            internal ManagedCodeCriteria(ManagedCodeConventions conventions)
             {
                 _conventions = conventions;
             }
@@ -164,45 +164,53 @@ namespace NuGet.Client
             }
         }
 
-        public class PatternSet
+        public class ManagedCodePatterns
         {
-            public ContentPatternDefinition RuntimeAssemblies { get; }
-            public ContentPatternDefinition CompileAssemblies { get; }
-            public ContentPatternDefinition NativeLibraries { get; }
+            public PatternSet RuntimeAssemblies { get; }
+            public PatternSet CompileAssemblies { get; }
+            public PatternSet NativeLibraries { get; }
 
-            internal PatternSet(ManagedCodeConventions conventions)
+            internal ManagedCodePatterns(ManagedCodeConventions conventions)
             {
-                RuntimeAssemblies = new ContentPatternDefinition(
+                RuntimeAssemblies = new PatternSet(
                     conventions.Properties,
-                    groupPatterns: new[]
+                    groupPatterns: new PatternDefinition[]
                     {
                         "runtimes/{rid}/lib/{tfm}/{any?}",
                         "lib/{tfm}/{any?}",
+                        new PatternDefinition("lib/{assembly?}", defaults: new Dictionary<string, object> 
+                        {
+                            { "tfm", new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.EmptyVersion) }
+                        })
                     },
-                    pathPatterns: new[]
+                    pathPatterns: new PatternDefinition[]
                     {
                         "runtimes/{rid}/lib/{tfm}/{assembly}",
                         "lib/{tfm}/{assembly}",
+                        new PatternDefinition("lib/{assembly}", defaults: new Dictionary<string, object> 
+                        {
+                            { "tfm", new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.EmptyVersion) }
+                        })
                     });
 
-                CompileAssemblies = new ContentPatternDefinition(
+                CompileAssemblies = new PatternSet(
                     conventions.Properties,
-                    groupPatterns: new[]
+                    groupPatterns: new PatternDefinition[]
                     {
                         "ref/{tfm}/{any?}",
                     },
-                    pathPatterns: new[] {
+                    pathPatterns: new PatternDefinition[] {
                         "ref/{tfm}/{assembly}",
                     });
 
-                NativeLibraries = new ContentPatternDefinition(
+                NativeLibraries = new PatternSet(
                     conventions.Properties,
-                    groupPatterns: new[]
+                    groupPatterns: new PatternDefinition[]
                     {
                         "runtimes/{rid}/native/{any?}",
                         "native/{any?}",
                     },
-                    pathPatterns: new[]
+                    pathPatterns: new PatternDefinition[]
                     {
                         "runtimes/{rid}/native/{any}",
                         "native/{any}",

--- a/src/NuGet.ContentModel/ContentItem.cs
+++ b/src/NuGet.ContentModel/ContentItem.cs
@@ -6,17 +6,11 @@ namespace NuGet.ContentModel
     public class ContentItem
     {
         public string Path { get; set; }
-        public string PhysicalPath { get; set; }
-        public IDictionary<string, object> Properties { get; set; }
-
-        public ContentItem()
-        {
-            Properties = new Dictionary<string, object>();
-        }
+        public IDictionary<string, object> Properties { get; } = new Dictionary<string, object>();
 
         public override string ToString()
         {
-            return Path + " -> " + PhysicalPath;
+            return Path;
         }
     }
 }

--- a/src/NuGet.ContentModel/ContentItemCollection.cs
+++ b/src/NuGet.ContentModel/ContentItemCollection.cs
@@ -31,12 +31,12 @@ namespace NuGet.ContentModel
             }
         }
 
-        public IEnumerable<ContentItem> FindItems(ContentPatternDefinition definition)
+        public IEnumerable<ContentItem> FindItems(PatternSet definition)
         {
             return FindItemsImplementation(definition, _assets);
         }
 
-        public IEnumerable<ContentItemGroup> FindItemGroups(ContentPatternDefinition definition)
+        public IEnumerable<ContentItemGroup> FindItemGroups(PatternSet definition)
         {
             var groupPatterns = definition.GroupPatterns
                 .Select(pattern => new Infrastructure.PatternExpression(pattern))
@@ -45,9 +45,9 @@ namespace NuGet.ContentModel
             var groupAssets = new List<Tuple<ContentItem, Asset>>();
             foreach (var asset in _assets)
             {
-                foreach (var groupParser in groupPatterns)
+                foreach (var groupPattern in groupPatterns)
                 {
-                    ContentItem item = groupParser.Match(asset.Path, definition.PropertyDefinitions);
+                    ContentItem item = groupPattern.Match(asset.Path, definition.PropertyDefinitions);
                     if (item != null)
                     {
                         groupAssets.Add(Tuple.Create(item, asset));
@@ -73,7 +73,7 @@ namespace NuGet.ContentModel
             }
         }
 
-        public ContentItemGroup FindBestItemGroup(SelectionCriteria criteria, params ContentPatternDefinition[] definitions)
+        public ContentItemGroup FindBestItemGroup(SelectionCriteria criteria, params PatternSet[] definitions)
         {
             foreach (var definition in definitions)
             {
@@ -170,7 +170,7 @@ namespace NuGet.ContentModel
             return null;
         }
 
-        private IEnumerable<ContentItem> FindItemsImplementation(ContentPatternDefinition definition, IEnumerable<Asset> assets)
+        private IEnumerable<ContentItem> FindItemsImplementation(PatternSet definition, IEnumerable<Asset> assets)
         {
             var pathPatterns = definition.PathPatterns
                 .Select(pattern => new Infrastructure.PatternExpression(pattern))

--- a/src/NuGet.ContentModel/ContentPropertyDefinition.cs
+++ b/src/NuGet.ContentModel/ContentPropertyDefinition.cs
@@ -7,7 +7,7 @@ namespace NuGet.ContentModel
 {
     /// <summary>
     /// Defines a property that can be used in Content Model query patterns
-    /// <seealso cref="ContentPatternDefinition"/>
+    /// <seealso cref="PatternSet"/>
     /// </summary>
     public class ContentPropertyDefinition
     {

--- a/src/NuGet.ContentModel/ContentQueryDefinition.cs
+++ b/src/NuGet.ContentModel/ContentQueryDefinition.cs
@@ -6,26 +6,56 @@ using System.Linq;
 namespace NuGet.ContentModel
 {
     /// <summary>
-    /// A pattern that can be used to query a set of file paths for items matching a provided criteria.
+    /// A set of patterns that can be used to query a set of file paths for items matching a provided criteria.
     /// </summary>
-    /// <remarks>
-    /// The pattern is defined as a sequence of literal path strings that must match exactly and property references,
-    /// wrapped in {} characters, which are tested for compatibility with the consumer-provided criteria.
-    /// <seealso cref="ContentPropertyDefinition"/>
-    /// </remarks>
-    public class ContentPatternDefinition
+    public class PatternSet
     {
-        public ContentPatternDefinition(IReadOnlyDictionary<string, ContentPropertyDefinition> properties, IEnumerable<string> groupPatterns, IEnumerable<string> pathPatterns)
+        public PatternSet(IReadOnlyDictionary<string, ContentPropertyDefinition> properties, IEnumerable<PatternDefinition> groupPatterns, IEnumerable<PatternDefinition> pathPatterns)
         {
             GroupPatterns = groupPatterns?.ToList()?.AsReadOnly() ?? Enumerable.Empty<string>(); 
             PathPatterns = pathPatterns?.ToList()?.AsReadOnly() ?? Enumerable.Empty<string>();
             PropertyDefinitions = properties;
         }
 
-        public IEnumerable<string> GroupPatterns { get; }
+        /// <summary>
+        /// Patterns used to select a group of items that matches the criteria
+        /// </summary>
+        public IEnumerable<PatternDefinition> GroupPatterns { get; }
 
-        public IEnumerable<string> PathPatterns { get; }
+        /// <summary>
+        /// Patterns used to select individual items that match the criteria
+        /// </summary>
+        public IEnumerable<PatternDefinition> PathPatterns { get; }
 
+        /// <summary>
+        /// Property definitions used for matching patterns
+        /// </summary>
         public IReadOnlyDictionary<string, ContentPropertyDefinition> PropertyDefinitions { get; set; }
+    }
+
+    /// <summary>
+    /// A pattern that can be used to match file paths given a provided criteria. 
+    /// </summary>
+    /// <remarks>
+    /// The pattern is defined as a sequence of literal path strings that must match exactly and property references,
+    /// wrapped in {} characters, which are tested for compatibility with the consumer-provided criteria.
+    /// <seealso cref="ContentPropertyDefinition"/>
+    /// </remarks>
+    public class PatternDefinition
+    {
+        public string Pattern { get; }
+        public IReadOnlyDictionary<string, object> Defaults { get; }
+
+        public PatternDefinition(string pattern) : this(pattern, Enumerable.Empty<KeyValuePair<string, object>>()) { }
+        public PatternDefinition(string pattern, IEnumerable<KeyValuePair<string, object>> defaults)
+        {
+            Pattern = pattern;
+            Defaults = new ReadOnlyDictionary<string, object>(defaults.ToDictionary(p => p.Key, p => p.Value));
+        }
+
+        public static implicit operator PatternDefinition(string pattern)
+        {
+            return new PatternDefinition(pattern);
+        }
     }
 }

--- a/src/NuGet.ContentModel/Infrastructure/Parser.cs
+++ b/src/NuGet.ContentModel/Infrastructure/Parser.cs
@@ -5,11 +5,13 @@ namespace NuGet.ContentModel.Infrastructure
 {
     public class PatternExpression
     {
-        private List<Segment> _segments = new List<Segment>();
+        private readonly List<Segment> _segments = new List<Segment>();
+        private readonly IReadOnlyDictionary<string, object> _defaults;
 
-        public PatternExpression(string pattern)
+        public PatternExpression(PatternDefinition pattern)
         {
-            Initialize(pattern);
+            _defaults = pattern.Defaults;
+            Initialize(pattern.Pattern);
         }
 
         private void Initialize(string pattern)
@@ -55,7 +57,18 @@ namespace NuGet.ContentModel.Infrastructure
                 }
                 return null;
             }
-            return startIndex == path.Length ? item : null;
+
+            if(startIndex == path.Length)
+            {
+                // Successful match!
+                // Apply defaults from the pattern
+                foreach(var pair in _defaults)
+                {
+                    item.Properties[pair.Key] = pair.Value;
+                }
+                return item;
+            }
+            return null;
         }
 
         private abstract class Segment


### PR DESCRIPTION
These fixes were made in @davidfowl 's prototype after I took the code. They're pretty minor.

The fixes add support for reading "lib/Foo.dll" and interpreting as though it was written "lib/net0/Foo.dll", this is a legacy pattern and generally isn't expected to be seen in modern packages. Also, the `references` node in the nuspec wasn't being respected.

/cc @davidfowl @emgarten @yishaigalatzer 
