### PR TITLE
Updating ExternalProjectReference

### DIFF
--- a/src/NuGet.Commands/RestoreRequest.cs
+++ b/src/NuGet.Commands/RestoreRequest.cs
@@ -36,7 +36,7 @@ namespace NuGet.Commands
         /// <summary>
         /// A list of projects provided by external build systems (i.e. MSBuild)
         /// </summary>
-        public IList<ExternalProjectReference> ExternalProjects { get; }
+        public IList<ExternalProjectReference> ExternalProjects { get; set; }
 
         /// <summary>
         /// The path to the lock file to read/write. If not specified, uses the file 'project.lock.json' in the same directory as the provided PackageSpec

--- a/src/NuGet.ProjectModel/ExternalProjectReference.cs
+++ b/src/NuGet.ProjectModel/ExternalProjectReference.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace NuGet.ProjectModel
 {
@@ -7,19 +9,69 @@ namespace NuGet.ProjectModel
     /// </summary>
     public class ExternalProjectReference
     {
+        private readonly string _name;
+        private readonly string _packageSpecPath;
+        private readonly IReadOnlyList<string> _projectReferences;
+
+        /// <summary>
+        /// Represents a reference to a project produced by an external build system, such as msbuild.
+        /// </summary>
+        /// <param name="name">unique project name or full path</param>
+        /// <param name="packageSpecPath">project.json path</param>
+        /// <param name="projectReferences">unique names of the referenced projects</param>
+        public ExternalProjectReference(string name, string packageSpecPath, IEnumerable<string> projectReferences)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (packageSpecPath == null)
+            {
+                throw new ArgumentNullException(nameof(packageSpecPath));
+            }
+
+            if (projectReferences == null)
+            {
+                throw new ArgumentNullException(nameof(projectReferences));
+            }
+
+            _name = name;
+            _packageSpecPath = packageSpecPath;
+            _projectReferences = projectReferences.ToList().AsReadOnly();
+        }
+
         /// <summary>
         /// The name of the external project
         /// </summary>
-        public string Name { get; }
+        public string Name
+        {
+            get
+            {
+                return _name;
+            }
+        }
 
         /// <summary>
         /// The path to the nuget.json file representing the NuGet dependencies of the project
         /// </summary>
-        public string PackageSpecPath { get; } 
+        public string PackageSpecPath
+        {
+            get
+            {
+                return _packageSpecPath;
+            }
+        }
 
         /// <summary>
         /// A list of other external projects this project references
         /// </summary>
-        public IReadOnlyList<string> ExternalProjectReferences { get; }
+        public IReadOnlyList<string> ExternalProjectReferences
+        {
+            get
+            {
+                return _projectReferences;
+            }
+        }
     }
 }


### PR DESCRIPTION
This change adds a constructor to ExternalProjectReference so that it can be used as is from NuGet.Commands and passed into the RestoreRequest context.

//cc @pranavkm 
