### PR TITLE
* Removing implicit cast to prevent cast exceptions.

### DIFF
--- a/src/NuGet.CommandLine/Program.cs
+++ b/src/NuGet.CommandLine/Program.cs
@@ -21,7 +21,7 @@ namespace NuGet.CommandLine
         public int Main(string[] args)
         {
 #if DEBUG
-            if(args.Contains("--debug"))
+            if (args.Contains("--debug"))
             {
                 args = args.Skip(1).ToArray();
                 System.Diagnostics.Debugger.Launch();
@@ -75,7 +75,7 @@ namespace NuGet.CommandLine
                             var packagesDir = packagesDirectory.HasValue() ?
                                 packagesDirectory.Value() :
                                 Path.Combine(Environment.GetEnvironmentVariable("USERPROFILE"), ".dnx", "packages");
-                            _log.LogVerbose($"Using packages directory: {packagesDirectory}");
+                            _log.LogVerbose($"Using packages directory: {packagesDir}");
 
                             // Run the restore
                             var request = new RestoreRequest(

--- a/src/NuGet.Commands/RestoreCommand.cs
+++ b/src/NuGet.Commands/RestoreCommand.cs
@@ -78,11 +78,11 @@ namespace NuGet.Commands
             var remoteWalker = new RemoteDependencyWalker(context);
 
             var projectRange = new LibraryRange()
-                {
-                    Name = request.Project.Name,
-                    VersionRange = new VersionRange(request.Project.Version),
-                    TypeConstraint = LibraryTypes.Project
-                };
+            {
+                Name = request.Project.Name,
+                VersionRange = new VersionRange(request.Project.Version),
+                TypeConstraint = LibraryTypes.Project
+            };
 
             // Resolve dependency graphs
             var frameworks = request.Project.TargetFrameworks.Select(f => f.FrameworkName).ToList();
@@ -305,25 +305,25 @@ namespace NuGet.Commands
 
             if (compileGroup != null)
             {
-                lockFileLib.CompileTimeAssemblies = compileGroup.Items.Select(t => t.Path).Cast<LockFileItem>().ToList();
+                lockFileLib.CompileTimeAssemblies = compileGroup.Items.Select(t => new LockFileItem(t.Path)).ToList();
             }
 
             var runtimeGroup = contentItems.FindBestItemGroup(managedCriteria, targetGraph.Conventions.Patterns.RuntimeAssemblies);
             if (runtimeGroup != null)
             {
-                lockFileLib.RuntimeAssemblies = runtimeGroup.Items.Select(p => p.Path).Cast<LockFileItem>().ToList();
+                lockFileLib.RuntimeAssemblies = runtimeGroup.Items.Select(p => new LockFileItem(p.Path)).ToList();
             }
-            
+
             var resourceGroup = contentItems.FindBestItemGroup(managedCriteria, targetGraph.Conventions.Patterns.ResourceAssemblies);
             if (resourceGroup != null)
             {
                 lockFileLib.ResourceAssemblies = resourceGroup.Items.Select(ToResourceLockFileItem).ToList();
-             }
+            }
 
             var nativeGroup = contentItems.FindBestItemGroup(nativeCriteria, targetGraph.Conventions.Patterns.NativeLibraries);
             if (nativeGroup != null)
             {
-                lockFileLib.NativeLibraries = nativeGroup.Items.Select(p => p.Path).Cast<LockFileItem>().ToList();
+                lockFileLib.NativeLibraries = nativeGroup.Items.Select(p => new LockFileItem(p.Path)).ToList();
             }
 
             // COMPAT: Support lib/contract so older packages can be consumed
@@ -336,7 +336,7 @@ namespace NuGet.Commands
                 && !framework.IsDesktop())
             {
                 lockFileLib.CompileTimeAssemblies.Clear();
-                lockFileLib.CompileTimeAssemblies.Add(contractPath);
+                lockFileLib.CompileTimeAssemblies.Add(new LockFileItem(contractPath));
             }
 
             // Apply filters from the <references> node in the nuspec
@@ -344,17 +344,17 @@ namespace NuGet.Commands
             {
                 // Remove anything that starts with "lib/" and is NOT specified in the reference filter.
                 // runtimes/* is unaffected (it doesn't start with lib/)
-                lockFileLib.RuntimeAssemblies = lockFileLib.RuntimeAssemblies.Where(p => !p.Path.StartsWith("lib/") || referenceFilter.Contains(p)).ToList();
-                lockFileLib.CompileTimeAssemblies = lockFileLib.CompileTimeAssemblies.Where(p => !p.Path.StartsWith("lib/") || referenceFilter.Contains(p)).ToList();
+                lockFileLib.RuntimeAssemblies = lockFileLib.RuntimeAssemblies.Where(p => !p.Path.StartsWith("lib/") || referenceFilter.Contains(p.Path)).ToList();
+                lockFileLib.CompileTimeAssemblies = lockFileLib.CompileTimeAssemblies.Where(p => !p.Path.StartsWith("lib/") || referenceFilter.Contains(p.Path)).ToList();
             }
 
             return lockFileLib;
         }
+
         private static LockFileItem ToResourceLockFileItem(ContentItem item)
         {
-            return new LockFileItem
+            return new LockFileItem(item.Path)
             {
-                Path = item.Path,
                 Properties =
                 {
                     { "locale", item.Properties["locale"].ToString()}

--- a/src/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -311,10 +311,19 @@ namespace NuGet.DependencyResolver
             var tasks = new List<Task<RemoteMatch>>();
             foreach (var provider in providers)
             {
-                Func<Task<RemoteMatch>> taskWrapper = async () => new RemoteMatch
+                Func<Task<RemoteMatch>> taskWrapper = async () =>
                 {
-                    Provider = provider,
-                    Library = await action(provider)
+                    var library = await action(provider);
+                    if (library != null)
+                    {
+                        return new RemoteMatch
+                        {
+                            Provider = provider,
+                            Library = await action(provider)
+                        };
+                    }
+
+                    return null;
                 };
 
                 tasks.Add(taskWrapper());

--- a/src/NuGet.ProjectModel/LockFileFormat.cs
+++ b/src/NuGet.ProjectModel/LockFileFormat.cs
@@ -295,7 +295,7 @@ namespace NuGet.ProjectModel
 
         private LockFileItem ReadFileItem(string property, JToken json)
         {
-            var item = new LockFileItem { Path = property };
+            var item = new LockFileItem(property);
             foreach (var subProperty in json.OfType<JProperty>())
             {
                 item.Properties[subProperty.Name] = subProperty.Value.Value<string>();

--- a/src/NuGet.ProjectModel/LockFileItem.cs
+++ b/src/NuGet.ProjectModel/LockFileItem.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGet.ProjectModel
+{
+    public class LockFileItem
+    {
+        public LockFileItem(string path)
+        {
+            Path = path;
+        }
+
+        public string Path { get; }
+
+        public IDictionary<string, string> Properties { get; } = new Dictionary<string, string>();
+
+        public override string ToString() => Path;
+    }
+}

--- a/src/NuGet.ProjectModel/LockFileLibrary.cs
+++ b/src/NuGet.ProjectModel/LockFileLibrary.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using NuGet.Frameworks;
-using NuGet.Packaging.Core;
 using NuGet.Versioning;
 
 namespace NuGet.ProjectModel
@@ -19,45 +17,5 @@ namespace NuGet.ProjectModel
         public string Sha512 { get; set; }
 
         public IList<string> Files { get; set; } = new List<string>();
-    }
-
-    public class LockFileTarget
-    {
-        public NuGetFramework TargetFramework { get; set; }
-
-        public string RuntimeIdentifier { get; set; }
-
-        public IList<LockFileTargetLibrary> Libraries { get; set; } = new List<LockFileTargetLibrary>();
-    }
-
-    public class LockFileTargetLibrary
-    {
-        public string Name { get; set; }
-
-        public NuGetVersion Version { get; set; }
-
-        public IList<PackageDependency> Dependencies { get; set; } = new List<PackageDependency>();
-
-        public IList<string> FrameworkAssemblies { get; set; } = new List<string>();
-
-        public IList<LockFileItem> RuntimeAssemblies { get; set; } = new List<LockFileItem>();
-        
-        public IList<LockFileItem> ResourceAssemblies { get; set; } = new List<LockFileItem>();
-
-        public IList<LockFileItem> CompileTimeAssemblies { get; set; } = new List<LockFileItem>();
-
-        public IList<LockFileItem> NativeLibraries { get; set; } = new List<LockFileItem>();
-    }
-    public class LockFileItem
-    {
-        public string Path { get; set; }
-
-        public IDictionary<string, string> Properties { get; } = new Dictionary<string, string>();
-
-        public static implicit operator string (LockFileItem item) => item.Path;
-        
-        public static implicit operator LockFileItem(string path) => new LockFileItem { Path = path };
-
-        public override string ToString() => Path;
     }
 }

--- a/src/NuGet.ProjectModel/LockFileTarget.cs
+++ b/src/NuGet.ProjectModel/LockFileTarget.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Frameworks;
+
+namespace NuGet.ProjectModel
+{
+    public class LockFileTarget
+    {
+        public NuGetFramework TargetFramework { get; set; }
+
+        public string RuntimeIdentifier { get; set; }
+
+        public IList<LockFileTargetLibrary> Libraries { get; set; } = new List<LockFileTargetLibrary>();
+    }
+}

--- a/src/NuGet.ProjectModel/LockFileTargetLibrary.cs
+++ b/src/NuGet.ProjectModel/LockFileTargetLibrary.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace NuGet.ProjectModel
+{
+    public class LockFileTargetLibrary
+    {
+        public string Name { get; set; }
+
+        public NuGetVersion Version { get; set; }
+
+        public IList<PackageDependency> Dependencies { get; set; } = new List<PackageDependency>();
+
+        public IList<string> FrameworkAssemblies { get; set; } = new List<string>();
+
+        public IList<LockFileItem> RuntimeAssemblies { get; set; } = new List<LockFileItem>();
+
+        public IList<LockFileItem> ResourceAssemblies { get; set; } = new List<LockFileItem>();
+
+        public IList<LockFileItem> CompileTimeAssemblies { get; set; } = new List<LockFileItem>();
+
+        public IList<LockFileItem> NativeLibraries { get; set; } = new List<LockFileItem>();
+    }
+}


### PR DESCRIPTION
- RemoteDependencyWalker null refs when match is non-null but the library
- is
- Print the package path correctly.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nuget/nuget3/27)

<!-- Reviewable:end -->
