### PR TITLE
added missing code for the locale property

### DIFF
--- a/NuGet3.sln
+++ b/NuGet3.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22815.1
+VisualStudioVersion = 14.0.22823.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{BD1946CE-5544-4F28-A04A-9C3D51113E1A}"
 EndProject
@@ -93,6 +93,14 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.Logging", "src\NuGet.Logging\NuGet.Logging.xproj", "{C1C5B715-CD4C-44C2-B074-BA638612AC2F}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.DependencyResolver.Core.Tests", "test\NuGet.DependencyResolver.Core.Tests\NuGet.DependencyResolver.Core.Tests.xproj", "{AD489758-39EE-43D6-B4B0-F94F2E465044}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "misc", "misc", "{C3FE3A91-76A3-4945-961F-EF767CB75319}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "RestoreTests", "RestoreTests", "{F52A8D55-09F2-44EC-8377-A9FF88AB2E97}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSBuild", "misc\RestoreTests\MSBuild\MSBuild.csproj", "{646B4C63-2CB1-4837-888F-75AB14E70DCE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSBuildWarning", "misc\RestoreTests\MSBuildWarning\MSBuildWarning.csproj", "{B799721A-EB8D-490B-8E36-E655A0BE8707}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -264,6 +272,14 @@ Global
 		{AD489758-39EE-43D6-B4B0-F94F2E465044}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AD489758-39EE-43D6-B4B0-F94F2E465044}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AD489758-39EE-43D6-B4B0-F94F2E465044}.Release|Any CPU.Build.0 = Release|Any CPU
+		{646B4C63-2CB1-4837-888F-75AB14E70DCE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{646B4C63-2CB1-4837-888F-75AB14E70DCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{646B4C63-2CB1-4837-888F-75AB14E70DCE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{646B4C63-2CB1-4837-888F-75AB14E70DCE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B799721A-EB8D-490B-8E36-E655A0BE8707}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B799721A-EB8D-490B-8E36-E655A0BE8707}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B799721A-EB8D-490B-8E36-E655A0BE8707}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B799721A-EB8D-490B-8E36-E655A0BE8707}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -310,5 +326,8 @@ Global
 		{002AE92E-01E5-4A38-996B-731A7A048D58} = {BD1946CE-5544-4F28-A04A-9C3D51113E1A}
 		{C1C5B715-CD4C-44C2-B074-BA638612AC2F} = {BD1946CE-5544-4F28-A04A-9C3D51113E1A}
 		{AD489758-39EE-43D6-B4B0-F94F2E465044} = {7323F93B-D141-4001-BB9E-7AF14031143E}
+		{F52A8D55-09F2-44EC-8377-A9FF88AB2E97} = {C3FE3A91-76A3-4945-961F-EF767CB75319}
+		{646B4C63-2CB1-4837-888F-75AB14E70DCE} = {F52A8D55-09F2-44EC-8377-A9FF88AB2E97}
+		{B799721A-EB8D-490B-8E36-E655A0BE8707} = {F52A8D55-09F2-44EC-8377-A9FF88AB2E97}
 	EndGlobalSection
 EndGlobal

--- a/src/NuGet.Client/ManagedCodeConventions.cs
+++ b/src/NuGet.Client/ManagedCodeConventions.cs
@@ -23,6 +23,8 @@ namespace NuGet.Client
                 },
             parser: TargetFrameworkName_Parser,
             compatibilityTest: TargetFrameworkName_CompatibilityTest);
+        private static readonly ContentPropertyDefinition LocaleProperty = new ContentPropertyDefinition(PropertyNames.Locale,
+            parser: Locale_Parser);
 
         private static readonly ContentPropertyDefinition AnyProperty = new ContentPropertyDefinition(PropertyNames.AnyValue);
         private static readonly ContentPropertyDefinition AssemblyProperty = new ContentPropertyDefinition(PropertyNames.ManagedAssembly, fileExtensions: new[] { ".dll" });
@@ -41,6 +43,7 @@ namespace NuGet.Client
             props[TfmProperty.Name] = TfmProperty;
             props[AnyProperty.Name] = AnyProperty;
             props[AssemblyProperty.Name] = AssemblyProperty;
+            props[LocaleProperty.Name] = LocaleProperty;
 
             props[PropertyNames.RuntimeIdentifier] = new ContentPropertyDefinition(
                 PropertyNames.RuntimeIdentifier,
@@ -70,6 +73,20 @@ namespace NuGet.Client
                 }
                 return false;
             }
+        }
+
+        private static object Locale_Parser(string name)
+        {
+            if (name.Length == 2)
+            {
+                return name;
+            }
+            else if (name.Length >= 4 && name[2] == '-')
+            {
+                return name;
+            }
+
+            return null;
         }
 
         private static object TargetFrameworkName_Parser(string name)
@@ -229,15 +246,15 @@ namespace NuGet.Client
                         "lib/{tfm}/{locale}/{resources}"
                     });
             }
-    }
+        }
 
-    public static class PropertyNames
-    {
-        public static readonly string TargetFrameworkMoniker = "tfm";
-        public static readonly string RuntimeIdentifier = "rid";
-        public static readonly string AnyValue = "any";
-        public static readonly string ManagedAssembly = "assembly";
-
+        public static class PropertyNames
+        {
+            public static readonly string TargetFrameworkMoniker = "tfm";
+            public static readonly string RuntimeIdentifier = "rid";
+            public static readonly string AnyValue = "any";
+            public static readonly string ManagedAssembly = "assembly";
+            public static readonly string Locale = "locale";
+        }
     }
-}
 }

--- a/src/NuGet.CommandLine/CommandOutputLogger.cs
+++ b/src/NuGet.CommandLine/CommandOutputLogger.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Framework.Runtime.Common.CommandLine;
 using NuGet.Logging;
 
@@ -73,7 +74,10 @@ namespace NuGet.CommandLine
                 caption = logLevel;
             }
 
-            AnsiConsole.GetOutput(_useConsoleColor).WriteLine($"{caption}: {message}");
+            lock(Console.Out)
+            {
+                AnsiConsole.GetOutput(_useConsoleColor).WriteLine($"{caption}: {message}");
+            }
         }
     }
 }


### PR DESCRIPTION
When @davidfowl ported the code @lodejard had written in DNX to handle satellite assemblies, he didn't realize that I had trimmed back the property definitions (since there were many that were not in use yet and I didn't want us accidentally shipping things we hadn't finished designing :)), so the `locale` property was missing.

This PR adds it back.

/cc @davidfowl @yishaigalatzer @pranavkm @emgarten 

Fixes NuGet/Home#590

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nuget/nuget3/30)

<!-- Reviewable:end -->
