### PR TITLE
RestoreCommand nearest framework support

### DIFF
--- a/NuGet3.sln
+++ b/NuGet3.sln
@@ -102,6 +102,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSBuild", "misc\RestoreTest
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSBuildWarning", "misc\RestoreTests\MSBuildWarning\MSBuildWarning.csproj", "{B799721A-EB8D-490B-8E36-E655A0BE8707}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.Commands.Test", "test\NuGet.Commands.Test\NuGet.Commands.Test.xproj", "{300EF061-69F9-46D5-9CDE-CA39F2817F69}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -280,6 +282,10 @@ Global
 		{B799721A-EB8D-490B-8E36-E655A0BE8707}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B799721A-EB8D-490B-8E36-E655A0BE8707}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B799721A-EB8D-490B-8E36-E655A0BE8707}.Release|Any CPU.Build.0 = Release|Any CPU
+		{300EF061-69F9-46D5-9CDE-CA39F2817F69}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{300EF061-69F9-46D5-9CDE-CA39F2817F69}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{300EF061-69F9-46D5-9CDE-CA39F2817F69}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{300EF061-69F9-46D5-9CDE-CA39F2817F69}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -329,5 +335,6 @@ Global
 		{F52A8D55-09F2-44EC-8377-A9FF88AB2E97} = {C3FE3A91-76A3-4945-961F-EF767CB75319}
 		{646B4C63-2CB1-4837-888F-75AB14E70DCE} = {F52A8D55-09F2-44EC-8377-A9FF88AB2E97}
 		{B799721A-EB8D-490B-8E36-E655A0BE8707} = {F52A8D55-09F2-44EC-8377-A9FF88AB2E97}
+		{300EF061-69F9-46D5-9CDE-CA39F2817F69} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 	EndGlobalSection
 EndGlobal

--- a/test/NuGet.Commands.Test/NuGet.Commands.Test.xproj
+++ b/test/NuGet.Commands.Test/NuGet.Commands.Test.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>300ef061-69f9-46d5-9cde-ca39f2817f69</ProjectGuid>
+    <RootNamespace>NuGet.Commands.Test</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1,0 +1,319 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class RestoreCommandTests : IDisposable
+    {
+        private ConcurrentBag<string> _testFolders = new ConcurrentBag<string>();
+
+        [Fact]
+        public async Task RestoreCommand_NuGetVersioning107RuntimeAssemblies()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger);
+
+            var sources = new List<PackageSource>();
+            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
+            var projectDir = TestFileSystemUtility.CreateRandomTestFolder();
+            _testFolders.Add(packagesDir);
+            _testFolders.Add(projectDir);
+
+            var specPath = Path.Combine(projectDir, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+
+            AddDependency(spec, "NuGet.Versioning", "1.0.7");
+
+            var request = new RestoreRequest(spec, sources, packagesDir);
+            request.MaxDegreeOfConcurrency = 1;
+            request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
+
+            var lockFileFormat = new LockFileFormat();
+
+            // Act
+            var result = await command.ExecuteAsync(request);
+            var installed = result.GetAllInstalled();
+            var unresolved = result.GetAllUnresolved();
+            var runtimeAssemblies = GetRuntimeAssemblies(result.LockFile.Targets, "netcore50", null);
+
+            var runtimeAssembly = runtimeAssemblies.FirstOrDefault();
+
+            // Assert
+            Assert.Equal(0, logger.Errors);
+            Assert.Equal(1, installed.Count);
+            Assert.Equal(0, unresolved.Count);
+            Assert.Equal("NuGet.Versioning", installed.Single().Name);
+            Assert.Equal("1.0.7", installed.Single().Version.ToNormalizedString());
+
+            Assert.Equal(1, runtimeAssemblies.Count);
+            Assert.Equal("lib/portable-net40+win/NuGet.Versioning.dll", runtimeAssembly.Path);
+        }
+
+        [Fact]
+        public async Task RestoreCommand_InstallPackageWithDependencies()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger);
+
+            var sources = new List<PackageSource>();
+            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
+            var projectDir = TestFileSystemUtility.CreateRandomTestFolder();
+            _testFolders.Add(packagesDir);
+            _testFolders.Add(projectDir);
+
+            var specPath = Path.Combine(projectDir, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+
+            AddDependency(spec, "WebGrease", "1.6.0");
+
+            var request = new RestoreRequest(spec, sources, packagesDir);
+            request.MaxDegreeOfConcurrency = 1;
+            request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
+
+            var lockFileFormat = new LockFileFormat();
+
+            // Act
+            var result = await command.ExecuteAsync(request);
+            var installed = result.GetAllInstalled();
+            var unresolved = result.GetAllUnresolved();
+            var runtimeAssemblies = GetRuntimeAssemblies(result.LockFile.Targets, "netcore50", null);
+            var jsonNetReference = runtimeAssemblies.SingleOrDefault(assembly => assembly.Path == "lib/netcore45/Newtonsoft.Json.dll");
+            var jsonNetPackage = installed.SingleOrDefault(package => package.Name == "Newtonsoft.Json");
+
+            // Assert
+            Assert.Equal(0, logger.Errors);
+            Assert.Equal(3, installed.Count);
+            Assert.Equal(0, unresolved.Count);
+            Assert.Equal("5.0.4", jsonNetPackage.Version.ToNormalizedString());
+
+            Assert.Equal(1, runtimeAssemblies.Count);
+            Assert.NotNull(jsonNetReference);
+        }
+
+        [Fact]
+        public async Task RestoreCommand_RestoreWithNoChanges()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger);
+
+            var sources = new List<PackageSource>();
+            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
+            var projectDir = TestFileSystemUtility.CreateRandomTestFolder();
+            _testFolders.Add(packagesDir);
+            _testFolders.Add(projectDir);
+
+            var specPath = Path.Combine(projectDir, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+
+            AddDependency(spec, "NuGet.Versioning", "1.0.7");
+
+            var request = new RestoreRequest(spec, sources, packagesDir);
+            request.MaxDegreeOfConcurrency = 1;
+            request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
+
+            var firstRun = await command.ExecuteAsync(request);
+
+            // Act
+            var result = await command.ExecuteAsync(request);
+            var installed = result.GetAllInstalled();
+            var unresolved = result.GetAllUnresolved();
+
+            // Assert
+            Assert.Equal(0, logger.Errors);
+            Assert.Equal(0, installed.Count);
+            Assert.Equal(0, unresolved.Count);
+        }
+
+        [Theory]
+        [InlineData("https://www.nuget.org/api/v2/")]
+        [InlineData("https://api.nuget.org/v3/index.json")]
+        public async Task RestoreCommand_PackageIsAddedToPackageCache(string source)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger);
+
+            var sources = new List<PackageSource>();
+            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
+            var projectDir = TestFileSystemUtility.CreateRandomTestFolder();
+            _testFolders.Add(packagesDir);
+            _testFolders.Add(projectDir);
+
+            var specPath = Path.Combine(projectDir, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+
+            AddDependency(spec, "NuGet.Versioning", "1.0.7");
+
+            var request = new RestoreRequest(spec, sources, packagesDir);
+            request.MaxDegreeOfConcurrency = 1;
+            request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
+
+            // Act
+            var result = await command.ExecuteAsync(request);
+            var nuspecPath = Path.Combine(packagesDir, "NuGet.Versioning", "1.0.7", "NuGet.Versioning.nuspec");
+
+            // Assert
+            Assert.True(File.Exists(nuspecPath));
+        }
+
+        [Fact]
+        public async Task RestoreCommand_JsonNet701Beta3RuntimeAssemblies()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger);
+
+            var sources = new List<PackageSource>();
+            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
+            var projectDir = TestFileSystemUtility.CreateRandomTestFolder();
+            _testFolders.Add(packagesDir);
+            _testFolders.Add(projectDir);
+
+            var specPath = Path.Combine(projectDir, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+
+            AddDependency(spec, "Newtonsoft.Json", "7.0.1-beta3");
+
+            var request = new RestoreRequest(spec, sources, packagesDir);
+            request.MaxDegreeOfConcurrency = 1;
+            request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
+
+            var lockFileFormat = new LockFileFormat();
+
+            // Act
+            var result = await command.ExecuteAsync(request);
+            var installed = result.GetAllInstalled();
+            var unresolved = result.GetAllUnresolved();
+            var runtimeAssemblies = GetRuntimeAssemblies(result.LockFile.Targets, "netcore50", null);
+
+            var runtimeAssembly = runtimeAssemblies.FirstOrDefault();
+
+            // Assert
+            Assert.Equal(0, logger.Errors);
+            Assert.Equal(1, installed.Count);
+            Assert.Equal(0, unresolved.Count);
+            Assert.Equal("Newtonsoft.Json", installed.Single().Name);
+            Assert.Equal("7.0.1-beta3", installed.Single().Version.ToNormalizedString());
+
+            Assert.Equal(1, runtimeAssemblies.Count);
+            Assert.Equal("lib/portable-net45+wp80+win8+wpa81+dnxcore50/Newtonsoft.Json.dll", runtimeAssembly.Path);
+        }
+
+        [Fact]
+        public async Task RestoreCommand_NoCompatibleRuntimeAssembliesForProject()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger);
+
+            var sources = new List<PackageSource>();
+            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
+            var projectDir = TestFileSystemUtility.CreateRandomTestFolder();
+            _testFolders.Add(packagesDir);
+            _testFolders.Add(projectDir);
+
+            var specPath = Path.Combine(projectDir, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+
+            AddDependency(spec, "NuGet.Core", "2.8.3");
+
+            var request = new RestoreRequest(spec, sources, packagesDir);
+            request.MaxDegreeOfConcurrency = 1;
+            request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
+
+            var lockFileFormat = new LockFileFormat();
+
+            // Act
+            var result = await command.ExecuteAsync(request);
+            var installed = result.GetAllInstalled();
+            var unresolved = result.GetAllUnresolved();
+            var runtimeAssemblies = GetRuntimeAssemblies(result.LockFile.Targets, "netcore50", null);
+
+            var runtimeAssembly = runtimeAssemblies.FirstOrDefault();
+
+            // Assert
+            Assert.Equal(0, logger.Errors);
+            Assert.Equal(2, installed.Count);
+            Assert.Equal(0, unresolved.Count);
+            Assert.Equal(0, runtimeAssemblies.Count);
+        }
+
+        private static List<LockFileItem> GetRuntimeAssemblies(IList<LockFileTarget> targets, string framework, string runtime)
+        {
+            return targets.Where(target => target.TargetFramework.Equals(NuGetFramework.Parse(framework)))
+            .Where(target => target.RuntimeIdentifier == runtime)
+            .SelectMany(target => target.Libraries)
+            .SelectMany(library => library.RuntimeAssemblies)
+            .ToList();
+        }
+
+        private static void AddDependency(PackageSpec spec, string id, string version)
+        {
+            var target = new LibraryDependency()
+            {
+                LibraryRange = new LibraryRange()
+                {
+                    Name = id,
+                    VersionRange = VersionRange.Parse(version)
+                }
+            };
+
+            if (spec.Dependencies == null)
+            {
+                spec.Dependencies = new List<LibraryDependency>();
+            }
+
+            spec.Dependencies.Add(target);
+        }
+
+        private static JObject BasicConfig
+        {
+            get
+            {
+                var json = new JObject();
+
+                var frameworks = new JObject();
+                frameworks["netcore50"] = new JObject();
+
+                json["dependencies"] = new JObject();
+
+                json["frameworks"] = frameworks;
+
+                json.Add("runtimes", JObject.Parse("{ \"uap10-x86\": { }, \"uap10-x86-aot\": { } }"));
+
+                return json;
+            }
+        }
+
+
+        public void Dispose()
+        {
+            // Clean up
+            foreach (var folder in _testFolders)
+            {
+                TestFileSystemUtility.DeleteRandomTestFolders(folder);
+            }
+        }
+    }
+}

--- a/test/NuGet.Commands.Test/TestLogger.cs
+++ b/test/NuGet.Commands.Test/TestLogger.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+
+namespace NuGet.Commands.Test
+{
+    public class TestLogger : NuGet.Logging.ILogger
+    {
+        /// <summary>
+        /// Logged messages
+        /// </summary>
+        public Queue<string> Messages { get; } = new Queue<string>();
+
+        public int Errors { get; set; }
+
+        public int Warnings { get; set; }
+
+        public void LogDebug(string data)
+        {
+            Messages.Enqueue(data);
+        }
+
+        public void LogError(string data)
+        {
+            Errors++;
+            Messages.Enqueue(data);
+        }
+
+        public void LogInformation(string data)
+        {
+            Messages.Enqueue(data);
+        }
+
+        public void LogVerbose(string data)
+        {
+            Messages.Enqueue(data);
+        }
+
+        public void LogWarning(string data)
+        {
+            Warnings++;
+            Messages.Enqueue(data);
+        }
+    }
+}

--- a/test/NuGet.Commands.Test/project.json
+++ b/test/NuGet.Commands.Test/project.json
@@ -1,0 +1,15 @@
+﻿{
+  "version": "3.1.0-*",
+  "dependencies": {
+    "NuGet.Commands": "3.1.0-*",
+    "xunit.runner.aspnet": "2.0.0-aspnet-*",
+    "NuGet.Test.Utility": "3.1.0-*"
+  },
+  "commands": {
+    "test": "xunit.runner.aspnet"
+  },
+  "frameworks": {
+    "dnx451": { },
+    "dnxcore50": { }
+  }
+}

--- a/test/NuGet.Test.Utility/TestFileSystemUtility.cs
+++ b/test/NuGet.Test.Utility/TestFileSystemUtility.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.IO;
+
+namespace NuGet.Test.Utility
+{
+    public class TestFileSystemUtility
+    {
+        private static readonly string NuGetTestFolder =
+            Path.Combine(Environment.GetEnvironmentVariable("temp"), "NuGetTestFolder");
+
+        public static string CreateRandomTestFolder()
+        {
+            var randomFolderName = Guid.NewGuid().ToString();
+            var path = Path.Combine(NuGetTestFolder, randomFolderName);
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        public static void DeleteRandomTestFolders(params string[] randomTestPaths)
+        {
+            foreach (var randomTestPath in randomTestPaths)
+            {
+                DeleteRandomTestFolder(randomTestPath);
+            }
+        }
+
+        private static void DeleteRandomTestFolder(string randomTestPath)
+        {
+            try
+            {
+                if (Directory.Exists(randomTestPath))
+                {
+                    Directory.Delete(randomTestPath, recursive: true);
+                }
+            }
+            catch (Exception)
+            {
+                // Ignore exception while deleting directories
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/611

Adding CompareTest to ContentPropertyDefinition to allow finding the nearest framework in scenarios where multiple frameworks are compatible with a project framework, and neither can be ruled out by checking compatibility between the framework options.
