### PR TITLE
Renaming Core50 to netportable50

### DIFF
--- a/src/NuGet.Client/ManagedCodeConventions.cs
+++ b/src/NuGet.Client/ManagedCodeConventions.cs
@@ -187,14 +187,14 @@ namespace NuGet.Client
                     builder = builder
                         // Take runtime-specific matches first!
                         .Add[PropertyNames.TargetFrameworkMoniker, framework][PropertyNames.RuntimeIdentifier, runtimeIdentifier]
-                        .Add[PropertyNames.TargetFrameworkMoniker, FrameworkConstants.CommonFrameworks.Core50][PropertyNames.RuntimeIdentifier, runtimeIdentifier]
+                        .Add[PropertyNames.TargetFrameworkMoniker, FrameworkConstants.CommonFrameworks.NetPortable50][PropertyNames.RuntimeIdentifier, runtimeIdentifier]
                         .Add[PropertyNames.TargetFrameworkMoniker, FrameworkConstants.SpecialIdentifiers.Any][PropertyNames.RuntimeIdentifier, runtimeIdentifier];
                 }
 
                 // Then try runtime-agnostic
                 builder = builder
                     .Add[PropertyNames.TargetFrameworkMoniker, framework]
-                    .Add[PropertyNames.TargetFrameworkMoniker, FrameworkConstants.CommonFrameworks.Core50]
+                    .Add[PropertyNames.TargetFrameworkMoniker, FrameworkConstants.CommonFrameworks.NetPortable50]
                     .Add[PropertyNames.TargetFrameworkMoniker, FrameworkConstants.SpecialIdentifiers.Any];
 
                 return builder.Criteria;

--- a/src/NuGet.Frameworks/CompatibilityProvider.cs
+++ b/src/NuGet.Frameworks/CompatibilityProvider.cs
@@ -62,6 +62,16 @@ namespace NuGet.Frameworks
                 return true;
             }
 
+            // for unsupported frameworks, check if the original strings match
+            if (target.OriginalString != null
+                && candidate.OriginalString != null
+                && target.IsUnsupported
+                && candidate.IsUnsupported
+                && string.Equals(target.OriginalString, candidate.OriginalString, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
             // special cased frameworks
             if (!target.IsSpecificFramework
                 || !candidate.IsSpecificFramework)
@@ -116,7 +126,6 @@ namespace NuGet.Frameworks
 
         private bool? IsPCLCompatible(NuGetFramework target, NuGetFramework candidate)
         {
-            // TODO: PCLs can only depend on other PCLs?
             if (target.IsPCL
                 && !candidate.IsPCL)
             {

--- a/src/NuGet.Frameworks/DefaultFrameworkMappings.cs
+++ b/src/NuGet.Frameworks/DefaultFrameworkMappings.cs
@@ -81,8 +81,7 @@ namespace NuGet.Frameworks
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.XamarinXboxOne, "xamarinxboxone"),
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.Dnx, "dnx"),
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.DnxCore, "dnxcore"),
-                            new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.CoreCLR, "core"),
-                            new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.NetCore, "netcore"), 
+                            new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.NetCore, "netcore"),
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.WinRT, "winrt"), // legacy
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.UAP, "uap"),
                         };
@@ -199,11 +198,6 @@ namespace NuGet.Frameworks
                                 FrameworkConstants.CommonFrameworks.DnxCore,
                                 FrameworkConstants.CommonFrameworks.DnxCore50),
 
-                            // core <-> core50
-                            new KeyValuePair<NuGetFramework, NuGetFramework>(
-                                FrameworkConstants.CommonFrameworks.Core,
-                                FrameworkConstants.CommonFrameworks.Core50),
-
                             // TODO: remove these rules post-RC
                             // aspnet <-> aspnet50
                             new KeyValuePair<NuGetFramework, NuGetFramework>(
@@ -265,9 +259,6 @@ namespace NuGet.Frameworks
                         {
                             // .NET is a subset of DNX
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.FrameworkIdentifiers.Dnx),
-
-                            // CoreCLR is a subset of DNXCore
-                            new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.CoreCLR, FrameworkConstants.FrameworkIdentifiers.DnxCore),
                         };
                 }
 
@@ -309,21 +300,29 @@ namespace NuGet.Frameworks
                                     new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCore, FrameworkConstants.Version5),
                                     new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCore, FrameworkConstants.Version5))),
 
-                            // NetCore50 supports Core50
+                            // NetCore50 supports netportable50
                             new OneWayCompatibilityMappingEntry(new FrameworkRange(
-                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCore, new Version(5, 0, 0, 0)),
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCore, FrameworkConstants.Version5),
                                 new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCore, FrameworkConstants.MaxVersion)),
                                 new FrameworkRange(
-                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.CoreCLR, FrameworkConstants.Version5),
-                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.CoreCLR, FrameworkConstants.Version5))),
+                                    FrameworkConstants.CommonFrameworks.NetPortable50,
+                                    FrameworkConstants.CommonFrameworks.NetPortable50)),
 
-                            // Net46 supports Core50
+                            // DNXCore50 supports netportable50
+                            new OneWayCompatibilityMappingEntry(new FrameworkRange(
+                                FrameworkConstants.CommonFrameworks.DnxCore50,
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.DnxCore, FrameworkConstants.MaxVersion)),
+                                new FrameworkRange(
+                                    FrameworkConstants.CommonFrameworks.NetPortable50,
+                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Portable, FrameworkConstants.MaxVersion))),
+
+                            // Net46 supports netportable50
                             new OneWayCompatibilityMappingEntry(new FrameworkRange(
                                 new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, new Version(4, 6, 0, 0)),
                                 new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.MaxVersion)),
                                 new FrameworkRange(
-                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.CoreCLR, FrameworkConstants.Version5),
-                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.CoreCLR, FrameworkConstants.Version5))),
+                                    FrameworkConstants.CommonFrameworks.NetPortable50,
+                                    FrameworkConstants.CommonFrameworks.NetPortable50)),
 
                             // Win projects support WinRT
                             new OneWayCompatibilityMappingEntry(new FrameworkRange(

--- a/src/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Frameworks/FrameworkConstants.cs
@@ -37,7 +37,6 @@ namespace NuGet.Frameworks
             public const string WindowsPhone = "WindowsPhone";
             public const string Windows = "Windows";
             public const string WindowsPhoneApp = "WindowsPhoneApp";
-            public const string CoreCLR = "Core";
             public const string Dnx = "DNX";
             public const string DnxCore = "DNXCore";
             public const string AspNet = "ASP.NET";
@@ -97,8 +96,7 @@ namespace NuGet.Frameworks
             public static readonly NuGetFramework DnxCore = new NuGetFramework(FrameworkIdentifiers.DnxCore, EmptyVersion);
             public static readonly NuGetFramework DnxCore50 = new NuGetFramework(FrameworkIdentifiers.DnxCore, Version5);
 
-            public static readonly NuGetFramework Core = new NuGetFramework(FrameworkIdentifiers.CoreCLR, EmptyVersion);
-            public static readonly NuGetFramework Core50 = new NuGetFramework(FrameworkIdentifiers.CoreCLR, Version5);
+            public static readonly NuGetFramework NetPortable50 = new NuGetFramework(FrameworkIdentifiers.Portable, Version5);
 
             public static readonly NuGetFramework UAP10 = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, Version10);
         }

--- a/src/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Frameworks/FrameworkConstants.cs
@@ -37,7 +37,7 @@ namespace NuGet.Frameworks
             public const string WindowsPhone = "WindowsPhone";
             public const string Windows = "Windows";
             public const string WindowsPhoneApp = "WindowsPhoneApp";
-            public const string CoreCLR = "CoreCLR";
+            public const string CoreCLR = "Core";
             public const string Dnx = "DNX";
             public const string DnxCore = "DNXCore";
             public const string AspNet = "ASP.NET";

--- a/src/NuGet.Frameworks/FrameworkNameProvider.cs
+++ b/src/NuGet.Frameworks/FrameworkNameProvider.cs
@@ -334,8 +334,6 @@ namespace NuGet.Frameworks
 
             var shortNames = shortPortableProfiles.Split(new char[] { '+' }, StringSplitOptions.RemoveEmptyEntries);
 
-            Debug.Assert(shortNames.Length > 0);
-
             var result = new List<NuGetFramework>();
             foreach (var name in shortNames)
             {

--- a/src/NuGet.Frameworks/FrameworkReducer.cs
+++ b/src/NuGet.Frameworks/FrameworkReducer.cs
@@ -48,9 +48,9 @@ namespace NuGet.Frameworks
             NuGetFramework nearest = null;
 
             // Unsupported frameworks always lose, throw them out unless it's all we were given
-            if (possibleFrameworks.Any(e => e != NuGetFramework.UnsupportedFramework))
+            if (possibleFrameworks.Any(e => !e.IsUnsupported))
             {
-                possibleFrameworks = possibleFrameworks.Where(e => e != NuGetFramework.UnsupportedFramework);
+                possibleFrameworks = possibleFrameworks.Where(e => !e.IsUnsupported);
             }
 
             // Try exact matches first

--- a/src/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Frameworks/NuGetFramework.cs
@@ -92,6 +92,14 @@ namespace NuGet.Frameworks
                 {
                     var parts = new List<string>(3) { Framework };
 
+                    // Core50 should be written as .NETPortable,Version=v5.0
+                    if (string.Equals(FrameworkConstants.FrameworkIdentifiers.CoreCLR, Framework, StringComparison.OrdinalIgnoreCase) 
+                        && String.IsNullOrEmpty(Profile)
+                        && Version >= FrameworkConstants.Version5)
+                    {
+                        parts = new List<string>(3) { FrameworkConstants.FrameworkIdentifiers.Portable };
+                    }
+
                     parts.Add(String.Format(CultureInfo.InvariantCulture, "Version=v{0}", GetDisplayVersion(Version)));
 
                     if (!String.IsNullOrEmpty(Profile))

--- a/test/NuGet.Frameworks.Test/CompatibilityTests.cs
+++ b/test/NuGet.Frameworks.Test/CompatibilityTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using NuGet.Frameworks;
 using Xunit;
 
@@ -22,9 +21,9 @@ namespace NuGet.Test
 
         [Theory]
         [InlineData("dnxcore50", "UAP10.0")]
-        [InlineData("core50", "UAP10.0")]
-        [InlineData("core", "UAP10.0")]
-        [InlineData("core50", "UAP")]
+        [InlineData("netportable50", "UAP10.0")]
+        [InlineData("netportable", "UAP10.0")]
+        [InlineData("netportable50", "UAP")]
         [InlineData("native", "UAP")]
         [InlineData("net46", "UAP")]
         public void Compatibility_PlatformOneWayNeg(string fw1, string fw2)
@@ -41,8 +40,7 @@ namespace NuGet.Test
         [InlineData("UAP10.0", "netcore50")]
         [InlineData("UAP10.0", "netcore45")]
         [InlineData("UAP10.0", "winrt45")]
-        [InlineData("UAP10.0", "Core50")]
-        [InlineData("UAP10.0", "Core")]
+        [InlineData("UAP10.0", "netportable50")]
         [InlineData("UAP10.0", "Win81")]
         [InlineData("UAP10.0", "Win8")]
         [InlineData("UAP10.0", "Win")]
@@ -76,17 +74,16 @@ namespace NuGet.Test
         [InlineData("dnx46", "dnx451")]
         [InlineData("dnx452", "dnx451")]
         [InlineData("dnx452", "dnx")]
-        [InlineData("dnxcore", "core50")]
-        [InlineData("dnxcore", "core")]
-        [InlineData("net46", "core50")]
-        [InlineData("dnx46", "core50")]
+        [InlineData("dnxcore", "netportable50")]
+        [InlineData("dnxcore", "netportable60")]
+        [InlineData("net46", "netportable50")]
+        [InlineData("dnx46", "netportable50")]
         [InlineData("aspnet50", "net40")]
         [InlineData("netcore50", "netcore45")]
-        [InlineData("netcore50", "core50")]
+        [InlineData("netcore50", "netportable50")]
         [InlineData("uap10.0", "portable-net45+win8")]
         [InlineData("uap10.0", "portable-net45+win8+wpa81")]
         [InlineData("uap10.0", "portable-net45+wpa81")]
-        [InlineData("uap10.0", "portable-net45+sl5+core50")]
         [InlineData("uap10.0", "portable-net45+sl5+netcore50")]
         [InlineData("uap10.0", "portable-net45+sl5+uap")]
         [InlineData("netcore50", "netcore451")]
@@ -134,15 +131,15 @@ namespace NuGet.Test
         [Theory]
         [InlineData("net45", "dnx451")]
         [InlineData("net45", "net46")]
-        [InlineData("core50", "net4")]
+        [InlineData("netportable50", "net4")]
         [InlineData("win81", "netcore50")]
         [InlineData("wpa81", "netcore50")]
         [InlineData("uap10.0", "portable-net45+sl5+wp8")]
-        [InlineData("netcore451", "core")]
+        [InlineData("netcore451", "netportable")]
         [InlineData("win8", "netcore451")]
-        [InlineData("netcore451", "core50")]
-        [InlineData("win81", "core50")]
-        [InlineData("wpa81", "core50")]
+        [InlineData("netcore451", "netportable50")]
+        [InlineData("win81", "netportable50")]
+        [InlineData("wpa81", "netportable50")]
         public void Compatibility_SimpleNonCompat(string fw1, string fw2)
         {
             var framework1 = NuGetFramework.Parse(fw1);
@@ -212,32 +209,52 @@ namespace NuGet.Test
         }
 
         [Theory]
+        [InlineData("sl2")]
         [InlineData("net45")]
+        [InlineData("net20")]
         [InlineData("netcore45")]
         [InlineData("win8")]
+        [InlineData("win81")]
+        [InlineData("wpa81")]
+        [InlineData("win10.0")]
         [InlineData("native")]
         [InlineData("dnx451")]
+        [InlineData("netportable")]
+        [InlineData("portable")]
+        [InlineData("portable-win8+net40+sl3")]
+        [InlineData("portable-net451+win8+dnxcore50")]
+        [InlineData(".NETPortable,Version=v4.6,Profile=Profile259")]
         public void Compatibility_CoreCompatNeg(string framework)
         {
+            // Arrange
             var framework1 = NuGetFramework.Parse(framework);
-            var framework2 = NuGetFramework.Parse("core50");
+            var framework2 = NuGetFramework.Parse("netportable50");
 
             var compat = DefaultCompatibilityProvider.Instance;
 
+            // Act & Assert
             Assert.False(compat.IsCompatible(framework1, framework2));
+            Assert.False(compat.IsCompatible(framework2, framework1));
         }
 
         [Theory]
+        [InlineData("net50")]
         [InlineData("net46")]
         [InlineData("dnx46")]
         [InlineData("dnxcore50")]
         [InlineData("dnxcore")]
+        [InlineData("netcore50")]
+        [InlineData("netcore6")]
+        [InlineData("UAP10.5")]
         public void Compatibility_CoreCompat(string framework)
         {
+            // Arrange
             var framework1 = NuGetFramework.Parse(framework);
-            var framework2 = NuGetFramework.Parse("core50");
+            var framework2 = NuGetFramework.Parse("netportable50");
 
             var compat = DefaultCompatibilityProvider.Instance;
+
+            // Act & Assert
 
             // verify that compatibility is inferred across all the mappings
             Assert.True(compat.IsCompatible(framework1, framework2));
@@ -249,9 +266,9 @@ namespace NuGet.Test
         [Fact]
         public void Compatibility_InferredCore()
         {
-            // dnxcore50 -> coreclr -> native
+            // dnxcore50 -> netportable50
             var framework1 = NuGetFramework.Parse("dnxcore50");
-            var framework2 = NuGetFramework.Parse("core50");
+            var framework2 = NuGetFramework.Parse("netportable50");
 
             var compat = DefaultCompatibilityProvider.Instance;
 
@@ -499,6 +516,21 @@ namespace NuGet.Test
             // Assert
             Assert.False(net40CompatibleWithNet20);
             Assert.True(net20CompatibleWithNet40);
+        }
+
+        [Theory]
+        [InlineData("madeup1", "mAdeup1")]
+        [InlineData("framework", "framework")]
+        public void CompareUnsupportedFrameworksOnOriginalString(string framework1, string framework2)
+        {
+            // Arrange
+            var fw1 = NuGetFramework.Parse(framework1);
+            var fw2 = NuGetFramework.Parse(framework2);
+            var compat = DefaultCompatibilityProvider.Instance;
+
+            // Assert & Act
+            Assert.True(compat.IsCompatible(fw1, fw2));
+            Assert.True(compat.IsCompatible(fw2, fw1));
         }
     }
 }

--- a/test/NuGet.Frameworks.Test/FrameworkReducerTests.cs
+++ b/test/NuGet.Frameworks.Test/FrameworkReducerTests.cs
@@ -46,6 +46,35 @@ namespace NuGet.Test
             Assert.Equal(expectedFramework, result.GetShortFolderName());
         }
 
+        [Theory]
+        [InlineData("netportable50")]
+        public void FrameworkReducer_JsonNetGetNearestLibGroupNotFound(string projectFramework)
+        {
+            // Arrange
+
+            // Get nearest lib group for newtonsoft.json 7.0.1-beta2
+            FrameworkReducer reducer = new FrameworkReducer();
+
+            var project = NuGetFramework.Parse(projectFramework);
+
+            List<NuGetFramework> frameworks = new List<NuGetFramework>()
+            {
+                NuGetFramework.Parse("net20"),
+                NuGetFramework.Parse("net35"),
+                NuGetFramework.Parse("net40"),
+                NuGetFramework.Parse("net45"),
+                NuGetFramework.Parse("portable-net40+wp80+win8+wpa81+sl5"),
+                NuGetFramework.Parse("portable-net45+wp80+win8+wpa81+aspnetcore50")
+            };
+
+            // Act
+            var result = reducer.GetNearest(project, frameworks);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+
         [Fact]
         public void FrameworkReducer_GetNearestUAPTie()
         {
@@ -114,16 +143,16 @@ namespace NuGet.Test
             var project = NuGetFramework.Parse("UAP10.0");
 
             var native = NuGetFramework.Parse("native");
-            var core50 = NuGetFramework.Parse("core50");
+            var netportable50 = NuGetFramework.Parse("netportable50");
             var dnx451 = NuGetFramework.Parse("dnx451");
             var dnxcore50 = NuGetFramework.Parse("dnxcore50");
             var net45 = NuGetFramework.Parse("net45");
 
-            var all = new NuGetFramework[] { native, core50, dnx451, dnxcore50, net45 };
+            var all = new NuGetFramework[] { native, netportable50, dnx451, dnxcore50, net45 };
 
             var result = reducer.GetNearest(project, all);
 
-            Assert.Equal(core50, result);
+            Assert.Equal(netportable50, result);
         }
 
         [Fact]
@@ -133,16 +162,16 @@ namespace NuGet.Test
 
             var project = NuGetFramework.Parse("UAP10.0");
 
-            var core = NuGetFramework.Parse("core50");
+            var netportable = NuGetFramework.Parse("netportable50");
             var dnx451 = NuGetFramework.Parse("dnx451");
             var dnxcore50 = NuGetFramework.Parse("dnxcore50");
             var net45 = NuGetFramework.Parse("net45");
 
-            var all = new NuGetFramework[] { core, dnx451, dnxcore50, net45 };
+            var all = new NuGetFramework[] { netportable, dnx451, dnxcore50, net45 };
 
             var result = reducer.GetNearest(project, all);
 
-            Assert.Equal(core, result);
+            Assert.Equal(netportable, result);
         }
 
         [Fact]
@@ -287,9 +316,9 @@ namespace NuGet.Test
             FrameworkReducer reducer = new FrameworkReducer();
 
             var dnxcore50 = NuGetFramework.Parse("dnxcore50");
-            var core50 = NuGetFramework.Parse("core50");
+            var netportable50 = NuGetFramework.Parse("netportable50");
 
-            var all = new NuGetFramework[] { dnxcore50, core50 };
+            var all = new NuGetFramework[] { dnxcore50, netportable50 };
 
             var result = reducer.GetNearest(NuGetFramework.AnyFramework, all);
 

--- a/test/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
+++ b/test/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
@@ -145,7 +145,8 @@ namespace NuGet.Test
         [InlineData(".NETPortable,Version=v5.0", ".NETPortable,Version=v5.0")]
         [InlineData("Portable,Version=v5.0", ".NETPortable,Version=v5.0")]
         [InlineData(".NETPortable,Version=v6.0", ".NETPortable,Version=v6.0")]
-        [InlineData("Core,Version=v5.0", ".NETPortable,Version=v5.0")]
+        [InlineData(".NETPortable,Version=v5.0", ".NETPortable,Version=v5.0")]
+        [InlineData(".NETPortable,Version=v4.6", ".NETPortable,Version=v4.6")]
         public void NuGetFramework_ParseFullName(string input, string expected)
         {
             string actual = NuGetFramework.Parse(input).DotNetFrameworkName;
@@ -154,6 +155,9 @@ namespace NuGet.Test
         }
 
         [Theory]
+        [InlineData("portable50", ".NETPortable,Version=v5.0")]
+        [InlineData("netportable5", ".NETPortable,Version=v5.0")]
+        [InlineData("netportable50", ".NETPortable,Version=v5.0")]
         [InlineData("portable-net45+win10.0", ".NETPortable,Version=v0.0,Profile=net45+win10.0")]
         [InlineData("portable-net45+win8", ".NETPortable,Version=v0.0,Profile=Profile7")]
         [InlineData("portable-win8+net45", ".NETPortable,Version=v0.0,Profile=Profile7")]
@@ -190,10 +194,14 @@ namespace NuGet.Test
         [InlineData("net10.1.2.3", ".NETFramework,Version=v10.1.2.3")]
         [InlineData("net45-cf", ".NETFramework,Version=v4.5,Profile=CompactFramework")]
         [InlineData("uap10.0", "UAP,Version=v10.0")]
-        [InlineData("core50", ".NETPortable,Version=v5.0")]
-        [InlineData("core60", ".NETPortable,Version=v6.0")]
-        [InlineData("core", ".NETPortable,Version=v5.0")]
-        [InlineData("core50-profile", "Core,Version=v5.0,Profile=profile")]
+        [InlineData("netportable", ".NETPortable,Version=v0.0")]
+        [InlineData("netportable50", ".NETPortable,Version=v5.0")]
+        [InlineData("netportable60", ".NETPortable,Version=v6.0")]
+        [InlineData("netportable61", ".NETPortable,Version=v6.1")]
+        [InlineData("netportable6.1", ".NETPortable,Version=v6.1")]
+        [InlineData("portable5", ".NETPortable,Version=v5.0")]
+        [InlineData("netportable50-profile", ".NETPortable,Version=v5.0,Profile=profile")]
+        [InlineData("portable50-profile", ".NETPortable,Version=v5.0,Profile=profile")]
         public void NuGetFramework_Basic(string folderName, string fullName)
         {
             string output = NuGetFramework.Parse(folderName).DotNetFrameworkName;
@@ -211,7 +219,11 @@ namespace NuGet.Test
         [InlineData("")]
         public void NuGetFramework_Unsupported(string folderName)
         {
-            Assert.Equal("Unsupported,Version=v0.0", NuGetFramework.Parse(folderName).DotNetFrameworkName);
+            // Act
+            var framework = NuGetFramework.Parse(folderName);
+
+            Assert.Equal("Unsupported,Version=v0.0", framework.DotNetFrameworkName);
+            Assert.Equal(folderName, framework.OriginalString);
         }
 
         [Fact]

--- a/test/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
+++ b/test/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
@@ -142,6 +142,10 @@ namespace NuGet.Test
         [InlineData(".NETPortable,Version=v0.0,Profile=Profile7", ".NETPortable,Version=v0.0,Profile=Profile7")]
         [InlineData("Portable,Version=v0.0,Profile=Profile7", ".NETPortable,Version=v0.0,Profile=Profile7")]
         [InlineData("uap,Version=v10.0.10030.1", "UAP,Version=v10.0.10030.1")]
+        [InlineData(".NETPortable,Version=v5.0", ".NETPortable,Version=v5.0")]
+        [InlineData("Portable,Version=v5.0", ".NETPortable,Version=v5.0")]
+        [InlineData(".NETPortable,Version=v6.0", ".NETPortable,Version=v6.0")]
+        [InlineData("Core,Version=v5.0", ".NETPortable,Version=v5.0")]
         public void NuGetFramework_ParseFullName(string input, string expected)
         {
             string actual = NuGetFramework.Parse(input).DotNetFrameworkName;
@@ -186,6 +190,10 @@ namespace NuGet.Test
         [InlineData("net10.1.2.3", ".NETFramework,Version=v10.1.2.3")]
         [InlineData("net45-cf", ".NETFramework,Version=v4.5,Profile=CompactFramework")]
         [InlineData("uap10.0", "UAP,Version=v10.0")]
+        [InlineData("core50", ".NETPortable,Version=v5.0")]
+        [InlineData("core60", ".NETPortable,Version=v6.0")]
+        [InlineData("core", ".NETPortable,Version=v5.0")]
+        [InlineData("core50-profile", "Core,Version=v5.0,Profile=profile")]
         public void NuGetFramework_Basic(string folderName, string fullName)
         {
             string output = NuGetFramework.Parse(folderName).DotNetFrameworkName;

--- a/test/NuGet.Frameworks.Test/NuGetFrameworkTests.cs
+++ b/test/NuGet.Frameworks.Test/NuGetFrameworkTests.cs
@@ -11,6 +11,7 @@ namespace NuGet.Test
     public class NuGetFrameworkTests
     {
         [Theory]
+        [InlineData("netportable50", "netportable5")]
         [InlineData("net45", "net45")]
         [InlineData("portable-net45+win8+monoandroid", "portable-net45+win8")]
         [InlineData("portable-net45+win8+xamarin.ios", "portable-net45+win8")]
@@ -37,6 +38,7 @@ namespace NuGet.Test
         }
 
         [Theory]
+        [InlineData("netportable5", "netportable50")]
         [InlineData("net45", "net45")]
         [InlineData("portable-net45+win8", "portable-net45+win8+monoandroid+monotouch")]
         [InlineData("portable-net45+win8", "portable-net45+win8+monoandroid+monotouch+xamarin.ios")]
@@ -63,6 +65,7 @@ namespace NuGet.Test
         }
 
         [Theory]
+        [InlineData("netportable5", "netportable500")]
         [InlineData("net45", "net450")]
         [InlineData("net45", "net4.5.0")]
         [InlineData("aspnetcore5", "aspnetcore500")]

--- a/test/NuGet.Packaging.Test/NuspecReaderTests.cs
+++ b/test/NuGet.Packaging.Test/NuspecReaderTests.cs
@@ -255,7 +255,7 @@ namespace NuGet.Packaging.Test
             // unsupported frameworks remain ungrouped
             Assert.Equal(5, dependencies.Count);
 
-            Assert.Equal(4, dependencies.Where(g => g.TargetFramework == NuGetFramework.UnsupportedFramework).Count());
+            Assert.Equal(4, dependencies.Where(g => g.TargetFramework.IsUnsupported).Count());
         }
 
         private static NuspecReader GetReader(string nuspec)


### PR DESCRIPTION
This change renames core50 to netportable50 and adds additional handling around portable frameworks to denote the difference between regular PCLs and .NETPortable 5.0. 

The order of compatibility is: 
UAP -> netcore50 -> netportable50

Note: NETPortable already existed as a framework synonym of .NETPortable in both NuGet.Frameworks and NuGet.Core, so only the framework version number can be used to differentiate between legacy PCLs and Core CLR portable libraries.

I've also added OriginalString to NuGetFramework to improve compatibility with unknown frameworks as part of this change.
