### PR TITLE
Rename core50 to dotnet

### DIFF
--- a/src/NuGet.Client/ManagedCodeConventions.cs
+++ b/src/NuGet.Client/ManagedCodeConventions.cs
@@ -187,14 +187,14 @@ namespace NuGet.Client
                     builder = builder
                         // Take runtime-specific matches first!
                         .Add[PropertyNames.TargetFrameworkMoniker, framework][PropertyNames.RuntimeIdentifier, runtimeIdentifier]
-                        .Add[PropertyNames.TargetFrameworkMoniker, FrameworkConstants.CommonFrameworks.Core50][PropertyNames.RuntimeIdentifier, runtimeIdentifier]
+                        .Add[PropertyNames.TargetFrameworkMoniker, FrameworkConstants.CommonFrameworks.DotNet50][PropertyNames.RuntimeIdentifier, runtimeIdentifier]
                         .Add[PropertyNames.TargetFrameworkMoniker, FrameworkConstants.SpecialIdentifiers.Any][PropertyNames.RuntimeIdentifier, runtimeIdentifier];
                 }
 
                 // Then try runtime-agnostic
                 builder = builder
                     .Add[PropertyNames.TargetFrameworkMoniker, framework]
-                    .Add[PropertyNames.TargetFrameworkMoniker, FrameworkConstants.CommonFrameworks.Core50]
+                    .Add[PropertyNames.TargetFrameworkMoniker, FrameworkConstants.CommonFrameworks.DotNet50]
                     .Add[PropertyNames.TargetFrameworkMoniker, FrameworkConstants.SpecialIdentifiers.Any];
 
                 return builder.Criteria;

--- a/src/NuGet.Frameworks/DefaultFrameworkMappings.cs
+++ b/src/NuGet.Frameworks/DefaultFrameworkMappings.cs
@@ -59,6 +59,7 @@ namespace NuGet.Frameworks
                 {
                     _identifierShortNames = new KeyValuePair<string, string>[]
                         {
+                            new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.NetPlatform, "dotnet"),
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.Net, "net"),
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.NetMicro, "netmf"),
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.Silverlight, "sl"),
@@ -81,7 +82,6 @@ namespace NuGet.Frameworks
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.XamarinXboxOne, "xamarinxboxone"),
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.Dnx, "dnx"),
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.DnxCore, "dnxcore"),
-                            new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.CoreCLR, "core"),
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.NetCore, "netcore"), 
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.WinRT, "winrt"), // legacy
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.UAP, "uap"),
@@ -199,10 +199,10 @@ namespace NuGet.Frameworks
                                 FrameworkConstants.CommonFrameworks.DnxCore,
                                 FrameworkConstants.CommonFrameworks.DnxCore50),
 
-                            // core <-> core50
+                            // dotnet <-> dotnet50
                             new KeyValuePair<NuGetFramework, NuGetFramework>(
-                                FrameworkConstants.CommonFrameworks.Core,
-                                FrameworkConstants.CommonFrameworks.Core50),
+                                FrameworkConstants.CommonFrameworks.DotNet,
+                                FrameworkConstants.CommonFrameworks.DotNet50),
 
                             // TODO: remove these rules post-RC
                             // aspnet <-> aspnet50
@@ -266,8 +266,8 @@ namespace NuGet.Frameworks
                             // .NET is a subset of DNX
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.FrameworkIdentifiers.Dnx),
 
-                            // CoreCLR is a subset of DNXCore
-                            new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.CoreCLR, FrameworkConstants.FrameworkIdentifiers.DnxCore),
+                            // DotNet is a subset of DNXCore
+                            new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.NetPlatform, FrameworkConstants.FrameworkIdentifiers.DnxCore),
                         };
                 }
 
@@ -309,21 +309,21 @@ namespace NuGet.Frameworks
                                     new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCore, FrameworkConstants.Version5),
                                     new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCore, FrameworkConstants.Version5))),
 
-                            // NetCore50 supports Core50
+                            // NetCore50 supports DotNet
                             new OneWayCompatibilityMappingEntry(new FrameworkRange(
-                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCore, new Version(5, 0, 0, 0)),
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCore, FrameworkConstants.Version5),
                                 new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCore, FrameworkConstants.MaxVersion)),
                                 new FrameworkRange(
-                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.CoreCLR, FrameworkConstants.Version5),
-                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.CoreCLR, FrameworkConstants.Version5))),
+                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetPlatform, FrameworkConstants.EmptyVersion),
+                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetPlatform, FrameworkConstants.Version5))),
 
-                            // Net46 supports Core50
+                            // Net46 supports DotNet
                             new OneWayCompatibilityMappingEntry(new FrameworkRange(
                                 new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, new Version(4, 6, 0, 0)),
                                 new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.MaxVersion)),
                                 new FrameworkRange(
-                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.CoreCLR, FrameworkConstants.Version5),
-                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.CoreCLR, FrameworkConstants.Version5))),
+                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetPlatform, FrameworkConstants.EmptyVersion),
+                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetPlatform, FrameworkConstants.Version5))),
 
                             // Win projects support WinRT
                             new OneWayCompatibilityMappingEntry(new FrameworkRange(
@@ -357,6 +357,42 @@ namespace NuGet.Frameworks
                 }
 
                 return _frameworkPrecedence;
+            }
+        }
+
+        private static KeyValuePair<NuGetFramework, NuGetFramework>[] _shortNameReplacements;
+
+        public IEnumerable<KeyValuePair<NuGetFramework, NuGetFramework>> ShortNameReplacements
+        {
+            get
+            {
+                if (_shortNameReplacements == null)
+                {
+                    _shortNameReplacements = new KeyValuePair<NuGetFramework, NuGetFramework>[]
+                    {
+                        new KeyValuePair<NuGetFramework, NuGetFramework>(FrameworkConstants.CommonFrameworks.DotNet50, FrameworkConstants.CommonFrameworks.DotNet)
+                    };
+                }
+
+                return _shortNameReplacements;
+            }
+        }
+
+        private static KeyValuePair<NuGetFramework, NuGetFramework>[] _fullNameReplacements;
+
+        public IEnumerable<KeyValuePair<NuGetFramework, NuGetFramework>> FullNameReplacements
+        {
+            get
+            {
+                if (_fullNameReplacements == null)
+                {
+                    _fullNameReplacements = new KeyValuePair<NuGetFramework, NuGetFramework>[]
+                    {
+                        new KeyValuePair<NuGetFramework, NuGetFramework>(FrameworkConstants.CommonFrameworks.DotNet, FrameworkConstants.CommonFrameworks.DotNet50)
+                    };
+                }
+
+                return _fullNameReplacements;
             }
         }
 

--- a/src/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Frameworks/FrameworkConstants.cs
@@ -29,6 +29,7 @@ namespace NuGet.Frameworks
 
         public static class FrameworkIdentifiers
         {
+            public const string NetPlatform = ".NETPlatform";
             public const string Net = ".NETFramework";
             public const string NetCore = ".NETCore";
             public const string WinRT = "WinRT"; // deprecated
@@ -37,7 +38,6 @@ namespace NuGet.Frameworks
             public const string WindowsPhone = "WindowsPhone";
             public const string Windows = "Windows";
             public const string WindowsPhoneApp = "WindowsPhoneApp";
-            public const string CoreCLR = "CoreCLR";
             public const string Dnx = "DNX";
             public const string DnxCore = "DNXCore";
             public const string AspNet = "ASP.NET";
@@ -97,8 +97,8 @@ namespace NuGet.Frameworks
             public static readonly NuGetFramework DnxCore = new NuGetFramework(FrameworkIdentifiers.DnxCore, EmptyVersion);
             public static readonly NuGetFramework DnxCore50 = new NuGetFramework(FrameworkIdentifiers.DnxCore, Version5);
 
-            public static readonly NuGetFramework Core = new NuGetFramework(FrameworkIdentifiers.CoreCLR, EmptyVersion);
-            public static readonly NuGetFramework Core50 = new NuGetFramework(FrameworkIdentifiers.CoreCLR, Version5);
+            public static readonly NuGetFramework DotNet = new NuGetFramework(FrameworkIdentifiers.NetPlatform, EmptyVersion);
+            public static readonly NuGetFramework DotNet50 = new NuGetFramework(FrameworkIdentifiers.NetPlatform, Version5);
 
             public static readonly NuGetFramework UAP10 = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, Version10);
         }

--- a/src/NuGet.Frameworks/NuGetFrameworkFactory.cs
+++ b/src/NuGet.Frameworks/NuGetFrameworkFactory.cs
@@ -367,11 +367,9 @@ namespace NuGet.Frameworks
         {
             framework = null;
 
-            if (StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "core50")
-                || StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "core")
-                || StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "core5"))
+            if (StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "dotnet"))
             {
-                framework = FrameworkConstants.CommonFrameworks.Core50;
+                framework = FrameworkConstants.CommonFrameworks.DotNet50;
             }
             else if (StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "dnx")
                      || StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "dnx451"))

--- a/src/NuGet.Frameworks/def/IFrameworkMappings.cs
+++ b/src/NuGet.Frameworks/def/IFrameworkMappings.cs
@@ -62,5 +62,17 @@ namespace NuGet.Frameworks
         /// Example: UAP10.0 -> win81, wpa81
         /// </summary>
         IEnumerable<string> FrameworkPrecedence { get; }
+
+        /// <summary>
+        /// Rewrite folder short names to the given value.
+        /// Ex: dotnet50 -> dotnet
+        /// </summary>
+        IEnumerable<KeyValuePair<NuGetFramework, NuGetFramework>> ShortNameReplacements { get; }
+
+        /// <summary>
+        /// Rewrite full framework names to the given value.
+        /// Ex: .NETPlatform,Version=v0.0 -> .NETPlatform,Version=v5.0
+        /// </summary>
+        IEnumerable<KeyValuePair<NuGetFramework, NuGetFramework>> FullNameReplacements { get; }
     }
 }

--- a/src/NuGet.Frameworks/def/IFrameworkNameProvider.cs
+++ b/src/NuGet.Frameworks/def/IFrameworkNameProvider.cs
@@ -95,5 +95,17 @@ namespace NuGet.Frameworks
         /// </summary>
         /// <returns>0 if no order can be determined, -1 if the first framework is preferred.</returns>
         int CompareFrameworks(NuGetFramework x, NuGetFramework y);
+
+        /// <summary>
+        /// Returns folder short names rewrites.
+        /// Ex: dotnet50 -> dotnet
+        /// </summary>
+        NuGetFramework GetShortNameReplacement(NuGetFramework framework);
+
+        /// <summary>
+        /// Returns full name rewrites.
+        /// Ex: .NETPlatform,Version=v0.0 -> .NETPlatform,Version=v5.0
+        /// </summary>
+        NuGetFramework GetFullNameReplacement(NuGetFramework framework);
     }
 }

--- a/test/NuGet.Frameworks.Test/CompatibilityTests.cs
+++ b/test/NuGet.Frameworks.Test/CompatibilityTests.cs
@@ -22,9 +22,9 @@ namespace NuGet.Test
 
         [Theory]
         [InlineData("dnxcore50", "UAP10.0")]
-        [InlineData("core50", "UAP10.0")]
-        [InlineData("core", "UAP10.0")]
-        [InlineData("core50", "UAP")]
+        [InlineData("dotnet50", "UAP10.0")]
+        [InlineData("dotnet", "UAP10.0")]
+        [InlineData("dotnet", "UAP")]
         [InlineData("native", "UAP")]
         [InlineData("net46", "UAP")]
         public void Compatibility_PlatformOneWayNeg(string fw1, string fw2)
@@ -41,8 +41,8 @@ namespace NuGet.Test
         [InlineData("UAP10.0", "netcore50")]
         [InlineData("UAP10.0", "netcore45")]
         [InlineData("UAP10.0", "winrt45")]
-        [InlineData("UAP10.0", "Core50")]
-        [InlineData("UAP10.0", "Core")]
+        [InlineData("UAP10.0", "dotnet")]
+        [InlineData("UAP10.0", "dotnet50")]
         [InlineData("UAP10.0", "Win81")]
         [InlineData("UAP10.0", "Win8")]
         [InlineData("UAP10.0", "Win")]
@@ -76,17 +76,17 @@ namespace NuGet.Test
         [InlineData("dnx46", "dnx451")]
         [InlineData("dnx452", "dnx451")]
         [InlineData("dnx452", "dnx")]
-        [InlineData("dnxcore", "core50")]
-        [InlineData("dnxcore", "core")]
-        [InlineData("net46", "core50")]
-        [InlineData("dnx46", "core50")]
+        [InlineData("dnxcore", "dotnet50")]
+        [InlineData("dnxcore", "dotnet")]
+        [InlineData("net46", "dotnet")]
+        [InlineData("dnx46", "dotnet")]
         [InlineData("aspnet50", "net40")]
         [InlineData("netcore50", "netcore45")]
-        [InlineData("netcore50", "core50")]
+        [InlineData("netcore50", "dotnet")]
         [InlineData("uap10.0", "portable-net45+win8")]
         [InlineData("uap10.0", "portable-net45+win8+wpa81")]
         [InlineData("uap10.0", "portable-net45+wpa81")]
-        [InlineData("uap10.0", "portable-net45+sl5+core50")]
+        [InlineData("uap10.0", "portable-net45+sl5+dotnet")]
         [InlineData("uap10.0", "portable-net45+sl5+netcore50")]
         [InlineData("uap10.0", "portable-net45+sl5+uap")]
         [InlineData("netcore50", "netcore451")]
@@ -134,15 +134,15 @@ namespace NuGet.Test
         [Theory]
         [InlineData("net45", "dnx451")]
         [InlineData("net45", "net46")]
-        [InlineData("core50", "net4")]
+        [InlineData("dotnet", "net4")]
         [InlineData("win81", "netcore50")]
         [InlineData("wpa81", "netcore50")]
         [InlineData("uap10.0", "portable-net45+sl5+wp8")]
-        [InlineData("netcore451", "core")]
+        [InlineData("netcore451", "dotnet")]
         [InlineData("win8", "netcore451")]
-        [InlineData("netcore451", "core50")]
-        [InlineData("win81", "core50")]
-        [InlineData("wpa81", "core50")]
+        [InlineData("netcore451", "dotnet")]
+        [InlineData("win81", "dotnet")]
+        [InlineData("wpa81", "dotnet")]
         public void Compatibility_SimpleNonCompat(string fw1, string fw2)
         {
             var framework1 = NuGetFramework.Parse(fw1);
@@ -217,10 +217,11 @@ namespace NuGet.Test
         [InlineData("win8")]
         [InlineData("native")]
         [InlineData("dnx451")]
-        public void Compatibility_CoreCompatNeg(string framework)
+        [InlineData("portable-net45+win8")]
+        public void Compatibility_DotNetNeg(string framework)
         {
             var framework1 = NuGetFramework.Parse(framework);
-            var framework2 = NuGetFramework.Parse("core50");
+            var framework2 = NuGetFramework.Parse("dotnet");
 
             var compat = DefaultCompatibilityProvider.Instance;
 
@@ -228,14 +229,18 @@ namespace NuGet.Test
         }
 
         [Theory]
+        [InlineData("net50")]
         [InlineData("net46")]
         [InlineData("dnx46")]
+        [InlineData("dnx50")]
         [InlineData("dnxcore50")]
         [InlineData("dnxcore")]
-        public void Compatibility_CoreCompat(string framework)
+        [InlineData("netcore50")]
+        [InlineData("netcore60")]
+        public void Compatibility_DotNetCompat(string framework)
         {
             var framework1 = NuGetFramework.Parse(framework);
-            var framework2 = NuGetFramework.Parse("core50");
+            var framework2 = NuGetFramework.Parse("dotnet");
 
             var compat = DefaultCompatibilityProvider.Instance;
 
@@ -246,12 +251,53 @@ namespace NuGet.Test
             Assert.True(!compat.IsCompatible(framework2, framework1));
         }
 
+
+        [Theory]
+        [InlineData("dotnet")]
+        [InlineData("dotnet50")]
+        public void Compatibility_DotNetProjectCompat(string framework)
+        {
+            // Arrange
+            var framework1 = NuGetFramework.Parse(framework);
+            var project = NuGetFramework.Parse("dotnet");
+
+            var compat = DefaultCompatibilityProvider.Instance;
+
+            // Act & Assert
+            Assert.True(compat.IsCompatible(project, framework1));
+        }
+
+        [Theory]
+        [InlineData("native")]
+        [InlineData("wpa81")]
+        [InlineData("UAP10.0")]
+        [InlineData("win8")]
+        [InlineData("net50")]
+        [InlineData("net46")]
+        [InlineData("dnx46")]
+        [InlineData("dnx50")]
+        [InlineData("dnxcore50")]
+        [InlineData("dnxcore")]
+        [InlineData("netcore50")]
+        [InlineData("netcore60")]
+        public void Compatibility_DotNetProjectCompatNeg(string framework)
+        {
+            // Arrange
+            var framework1 = NuGetFramework.Parse(framework);
+            var project = NuGetFramework.Parse("dotnet");
+
+            var compat = DefaultCompatibilityProvider.Instance;
+
+            // Act & Assert
+            Assert.False(compat.IsCompatible(project, framework1));
+        }
+
         [Fact]
-        public void Compatibility_InferredCore()
+        public void Compatibility_InferredDotNet()
         {
             // dnxcore50 -> coreclr -> native
             var framework1 = NuGetFramework.Parse("dnxcore50");
-            var framework2 = NuGetFramework.Parse("core50");
+            var framework2 = NuGetFramework.Parse("dotnet");
 
             var compat = DefaultCompatibilityProvider.Instance;
 

--- a/test/NuGet.Frameworks.Test/FrameworkReducerTests.cs
+++ b/test/NuGet.Frameworks.Test/FrameworkReducerTests.cs
@@ -114,16 +114,16 @@ namespace NuGet.Test
             var project = NuGetFramework.Parse("UAP10.0");
 
             var native = NuGetFramework.Parse("native");
-            var core50 = NuGetFramework.Parse("core50");
+            var dotnet = NuGetFramework.Parse("dotnet");
             var dnx451 = NuGetFramework.Parse("dnx451");
             var dnxcore50 = NuGetFramework.Parse("dnxcore50");
             var net45 = NuGetFramework.Parse("net45");
 
-            var all = new NuGetFramework[] { native, core50, dnx451, dnxcore50, net45 };
+            var all = new NuGetFramework[] { native, dotnet, dnx451, dnxcore50, net45 };
 
             var result = reducer.GetNearest(project, all);
 
-            Assert.Equal(core50, result);
+            Assert.Equal(dotnet, result);
         }
 
         [Fact]
@@ -133,16 +133,16 @@ namespace NuGet.Test
 
             var project = NuGetFramework.Parse("UAP10.0");
 
-            var core = NuGetFramework.Parse("core50");
+            var dotnet = NuGetFramework.Parse("dotnet");
             var dnx451 = NuGetFramework.Parse("dnx451");
             var dnxcore50 = NuGetFramework.Parse("dnxcore50");
             var net45 = NuGetFramework.Parse("net45");
 
-            var all = new NuGetFramework[] { core, dnx451, dnxcore50, net45 };
+            var all = new NuGetFramework[] { dotnet, dnx451, dnxcore50, net45 };
 
             var result = reducer.GetNearest(project, all);
 
-            Assert.Equal(core, result);
+            Assert.Equal(dotnet, result);
         }
 
         [Fact]
@@ -287,9 +287,9 @@ namespace NuGet.Test
             FrameworkReducer reducer = new FrameworkReducer();
 
             var dnxcore50 = NuGetFramework.Parse("dnxcore50");
-            var core50 = NuGetFramework.Parse("core50");
+            var dotnet = NuGetFramework.Parse("dotnet");
 
-            var all = new NuGetFramework[] { dnxcore50, core50 };
+            var all = new NuGetFramework[] { dnxcore50, dotnet };
 
             var result = reducer.GetNearest(NuGetFramework.AnyFramework, all);
 

--- a/test/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
+++ b/test/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
@@ -125,6 +125,7 @@ namespace NuGet.Test
         }
 
         [Theory]
+        [InlineData(".NETPlatform50", ".NETPlatform,Version=v5.0")]
         [InlineData(".NETFramework45", ".NETFramework,Version=v4.5")]
         [InlineData("Portable-net45+win8", ".NETPortable,Version=v0.0,Profile=Profile7")]
         [InlineData("windows8", "Windows,Version=v8.0")]
@@ -137,6 +138,9 @@ namespace NuGet.Test
         }
 
         [Theory]
+        [InlineData(".NETPlatform,Version=v1.0", ".NETPlatform,Version=v1.0")]
+        [InlineData(".NETPlatform,Version=v0.0", ".NETPlatform,Version=v5.0")]
+        [InlineData(".NETPlatform,Version=v5.0", ".NETPlatform,Version=v5.0")]
         [InlineData(".NETFramework,Version=v4.5", ".NETFramework,Version=v4.5")]
         [InlineData("NETFramework,Version=v4.5", ".NETFramework,Version=v4.5")]
         [InlineData(".NETPortable,Version=v0.0,Profile=Profile7", ".NETPortable,Version=v0.0,Profile=Profile7")]
@@ -177,6 +181,32 @@ namespace NuGet.Test
 
         [Theory]
         [InlineData("net45", ".NETFramework,Version=v4.5")]
+        [InlineData("net2", ".NETFramework,Version=v2.0")]
+        [InlineData("net4", ".NETFramework,Version=v4.0")]
+        [InlineData("net35", ".NETFramework,Version=v3.5")]
+        [InlineData("net4", ".NETFramework,Version=v4.0")]
+        [InlineData("net4-client", ".NETFramework,Version=v4.0,Profile=Client")]
+        [InlineData("net", ".NETFramework,Version=v0.0")]
+        [InlineData("net10.1.2.3", ".NETFramework,Version=v10.1.2.3")]
+        [InlineData("net45-cf", ".NETFramework,Version=v4.5,Profile=CompactFramework")]
+        [InlineData("uap10.0", "UAP,Version=v10.0")]
+        [InlineData("dotnet", ".NETPlatform,Version=v0.0")]
+        [InlineData("dotnet", ".NETPlatform,Version=v5.0")]
+        [InlineData("dotnet1", ".NETPlatform,Version=v1.0")]
+        public void NuGetFramework_ParseToShortName(string expected, string fullName)
+        {
+            // Arrange
+            var framework = NuGetFramework.Parse(fullName);
+
+            // Act
+            var shortName = framework.GetShortFolderName();
+
+            // Assert
+            Assert.Equal(expected, shortName);
+        }
+
+        [Theory]
+        [InlineData("net45", ".NETFramework,Version=v4.5")]
         [InlineData("net20", ".NETFramework,Version=v2.0")]
         [InlineData("net40", ".NETFramework,Version=v4.0")]
         [InlineData("net35", ".NETFramework,Version=v3.5")]
@@ -186,6 +216,10 @@ namespace NuGet.Test
         [InlineData("net10.1.2.3", ".NETFramework,Version=v10.1.2.3")]
         [InlineData("net45-cf", ".NETFramework,Version=v4.5,Profile=CompactFramework")]
         [InlineData("uap10.0", "UAP,Version=v10.0")]
+        [InlineData("dotnet", ".NETPlatform,Version=v5.0")]
+        [InlineData("dotnet5", ".NETPlatform,Version=v5.0")]
+        [InlineData("dotnet50", ".NETPlatform,Version=v5.0")]
+        [InlineData("dotnet10", ".NETPlatform,Version=v1.0")]
         public void NuGetFramework_Basic(string folderName, string fullName)
         {
             string output = NuGetFramework.Parse(folderName).DotNetFrameworkName;


### PR DESCRIPTION
Rename core50 to dotnet

Add support for rewriting frameworks when parsing them to string format. 
Ex: dotnet50 -> dotnet
.NETPlatform,Version=v0.0 -> .NETPlatform,Version=v5.0
