### PR TITLE
Normalize versions in package paths

### DIFF
--- a/src/NuGet.Packaging/DefaultPackagePathResolver.cs
+++ b/src/NuGet.Packaging/DefaultPackagePathResolver.cs
@@ -35,17 +35,17 @@ namespace NuGet.Packaging
         public string GetHashPath(string packageId, SemanticVersion version)
         {
             return Path.Combine(GetInstallPath(packageId, version),
-                string.Format("{0}.{1}.nupkg.sha512", packageId, version));
+                string.Format("{0}.{1}.nupkg.sha512", packageId, version.ToNormalizedString()));
         }
 
         public virtual string GetPackageDirectory(string packageId, SemanticVersion version)
         {
-            return Path.Combine(packageId, version.ToString());
+            return Path.Combine(packageId, version.ToNormalizedString());
         }
 
         public virtual string GetPackageFileName(string packageId, SemanticVersion version)
         {
-            return string.Format("{0}.{1}.nupkg", packageId, version);
+            return string.Format("{0}.{1}.nupkg", packageId, version.ToNormalizedString());
         }
 
         public virtual string GetManifestFileName(string packageId, SemanticVersion version)

--- a/src/NuGet.Repositories/LocalPackageInfo.cs
+++ b/src/NuGet.Repositories/LocalPackageInfo.cs
@@ -14,7 +14,7 @@ namespace NuGet.Repositories
             Version = version;
             ExpandedPath = path;
             ManifestPath = Path.Combine(path, string.Format("{0}.nuspec", Id));
-            ZipPath = Path.Combine(path, string.Format("{0}.{1}.nupkg", Id, Version));
+            ZipPath = Path.Combine(path, string.Format("{0}.{1}.nupkg", Id, Version.ToNormalizedString()));
         }
 
         public string Id { get; }


### PR DESCRIPTION
This change updates DefaultPackagePathResolver to use normalized versions in paths.

For V3 we should avoid the problems non-normalized versions create when trying to find package paths.
