### PR TITLE
Use Name instead of Path when setting up root ExternalProjectReference.

### DIFF
--- a/src/NuGet.Commands/RestoreCommand.cs
+++ b/src/NuGet.Commands/RestoreCommand.cs
@@ -59,7 +59,7 @@ namespace NuGet.Commands
             if (request.ExternalProjects.Any())
             {
                 externalProjectReference = new ExternalProjectReference(
-                    request.Project.FilePath,
+                    request.Project.Name,
                     request.Project.FilePath,
                     request.ExternalProjects.Select(p => p.UniqueName));
             }


### PR DESCRIPTION
cc @emgarten @anurse 
