### PR TITLE
Add PCL guardrails

### DIFF
--- a/misc/RestoreTests/PclExample/project.json
+++ b/misc/RestoreTests/PclExample/project.json
@@ -1,0 +1,13 @@
+{
+    "dependencies": {
+        "System.Linq": "4.0.0-beta-*",
+        "Microsoft.NETCore.Targets": "1.0.0-beta-*"
+    },
+    "frameworks": {
+        "core50": {}
+    },
+    "supports": {
+        "netcore50": ["win8-x86", "win8-x64"],
+        "dnxcore50": []
+    }
+}

--- a/misc/RestoreTests/SimpleGraph/project.json
+++ b/misc/RestoreTests/SimpleGraph/project.json
@@ -5,8 +5,7 @@
         "Microsoft.NETCore.Runtime": "1.0.0-*"
     },
     "frameworks": {
-        "dnx451": {},
-        "dnxcore50": {}
+	"net45": {}
     },
     "runtimes": {
         "win8-x86": {},

--- a/misc/RestoreTests/SupportsTest/project.json
+++ b/misc/RestoreTests/SupportsTest/project.json
@@ -1,0 +1,15 @@
+{
+    "dependencies": {},
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "System.Console": "4.0.0-beta-*"
+            }
+        },
+        "sl40": {
+            "dependencies": {
+                "System.Console": "4.0.0-beta-*"
+            }
+        }
+    }
+}

--- a/src/NuGet.Commands/CompatibilityCheckResult.cs
+++ b/src/NuGet.Commands/CompatibilityCheckResult.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace NuGet.Commands
+{
+    public class CompatibilityCheckResult
+    {
+        public RestoreTargetGraph Graph { get; }
+
+        public IReadOnlyList<CompatibilityIssue> Issues { get; }
+
+        public bool Success => !Issues.Any();
+
+        public CompatibilityCheckResult(RestoreTargetGraph graph, IEnumerable<CompatibilityIssue> issues)
+        {
+            Graph = graph;
+            Issues = issues.ToList().AsReadOnly();
+        } 
+    }
+}

--- a/src/NuGet.Commands/CompatibilityIssue.cs
+++ b/src/NuGet.Commands/CompatibilityIssue.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using NuGet.Frameworks;
+using NuGet.Packaging.Core;
+
+namespace NuGet.Commands
+{
+    public class CompatibilityIssue : IEquatable<CompatibilityIssue>
+    {
+        public CompatibilityIssueType Type { get; }
+        public NuGetFramework Framework { get; }
+        public string RuntimeIdentifier { get; }
+        public string AssemblyName { get; }
+        public PackageIdentity Package { get; }
+
+        private CompatibilityIssue(CompatibilityIssueType type, PackageIdentity package, string assemblyName, NuGetFramework framework, string runtimeIdentifier)
+        {
+            Type = type;
+            AssemblyName = assemblyName;
+            Package = package;
+            Framework = framework;
+            RuntimeIdentifier = runtimeIdentifier;
+        }
+
+        public static CompatibilityIssue ReferenceAssemblyNotImplemented(string assemblyName, PackageIdentity referenceAssemblyPackage, NuGetFramework framework, string runtimeIdentifier)
+        {
+            return new CompatibilityIssue(CompatibilityIssueType.ReferenceAssemblyNotImplemented, referenceAssemblyPackage, assemblyName, framework, runtimeIdentifier);
+        }
+
+        public static CompatibilityIssue Incompatible(PackageIdentity referenceAssemblyPackage, NuGetFramework framework, string runtimeIdentifier)
+        {
+            return new CompatibilityIssue(CompatibilityIssueType.PackageIncompatible, referenceAssemblyPackage, string.Empty, framework, runtimeIdentifier);
+        }
+
+        public override string ToString()
+        {
+            // NOTE(anurse): Why not just use Format's implementation as ToString? I feel like ToString should be
+            // reserved for debug output, and just because they will be the same here doesn't mean it isn't useful
+            // to have a separate method for the, semantically different, behavior of rendering a message for user
+            // display, even though the results are the same.
+            return Format();
+        }
+
+        public string Format()
+        {
+            switch (Type)
+            {
+                case CompatibilityIssueType.ReferenceAssemblyNotImplemented:
+                    if (string.IsNullOrEmpty(RuntimeIdentifier))
+                    {
+                        return Strings.FormatLog_MissingImplementationFx(Package.Id, Package.Version, AssemblyName, Framework);
+                    }
+                    return Strings.FormatLog_MissingImplementationFxRuntime(Package.Id, Package.Version, AssemblyName, Framework, RuntimeIdentifier);
+                case CompatibilityIssueType.PackageIncompatible:
+                    return Strings.FormatLog_PackageNotCompatibleWithFx(Package.Id, Package.Version, RestoreTargetGraph.GetName(Framework, RuntimeIdentifier));
+                default:
+                    return null;
+            }
+        }
+
+        public bool Equals(CompatibilityIssue other)
+        {
+            return other != null &&
+                Equals(Type, other.Type) &&
+                Equals(Framework, other.Framework) &&
+                string.Equals(RuntimeIdentifier, other.RuntimeIdentifier, StringComparison.Ordinal) &&
+                string.Equals(AssemblyName, other.AssemblyName, StringComparison.Ordinal) &&
+                Equals(Package, other.Package);  
+        }
+    }
+
+    public enum CompatibilityIssueType
+    {
+        ReferenceAssemblyNotImplemented,
+        PackageIncompatible
+    }
+}

--- a/src/NuGet.Commands/CompatilibityChecker.cs
+++ b/src/NuGet.Commands/CompatilibityChecker.cs
@@ -1,0 +1,209 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.DependencyResolver;
+using NuGet.LibraryModel;
+using NuGet.Logging;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using NuGet.Repositories;
+
+namespace NuGet.Commands
+{
+    internal class CompatibilityChecker
+    {
+        private readonly NuGetv3LocalRepository _localRepository;
+        private readonly LockFile _lockFile;
+        private readonly ILogger _log;
+
+        public CompatibilityChecker(NuGetv3LocalRepository localRepository, LockFile lockFile, ILogger log)
+        {
+            _localRepository = localRepository;
+            _lockFile = lockFile;
+            _log = log;
+        }
+
+        internal CompatibilityCheckResult Check(RestoreTargetGraph graph)
+        {
+            // The Compatibility Check is designed to alert the user to cases where packages are not behaving as they would
+            // expect, due to compatibility issues.
+            //
+            // During this check, we scan all packages for a given restore graph and check the following conditions
+            // (using an example TxM 'foo' and an example Runtime ID 'bar'):
+            //
+            // * If any package provides a "ref/foo/Thingy.dll", there MUST be a matching "lib/foo/Thingy.dll" or
+            //   "runtimes/bar/lib/foo/Thingy.dll" provided by a package in the graph.
+            // * All packages that contain Managed Assemblies must provide assemblies for 'foo'. If a package
+            //   contains any of 'ref/' folders, 'lib/' folders, or framework assemblies, it must provide at least
+            //   one of those for the 'foo' framework. Otherwise, the package is intending to provide managed assemblies
+            //   but it does not support the target platform. If a package contains only 'content/', 'build/', 'tools/' or
+            //   other NuGet convention folders, it is exempt from this check. Thus, content-only packages are always considered
+            //   compatible, regardless of if they actually provide useful content.
+            //
+            // It is up to callers to invoke the compatibility check on the graphs they wish to check, but the general behavior in
+            // the restore command is to invoke a compatibility check for each of:
+            //
+            // * The Targets (TxMs) defined in the project.json, with no Runtimes
+            // * All combinations of TxMs and Runtimes defined in the project.json
+            // * Additional (TxMs, Runtime) pairs defined by the "supports" mechanism in project.json
+
+
+            var runtimeAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var compileAssemblies = new Dictionary<string, LibraryIdentity>(StringComparer.OrdinalIgnoreCase);
+            var issues = new List<CompatibilityIssue>();
+            foreach (var node in graph.Flattened)
+            {
+                _log.LogDebug(Strings.FormatLog_CheckingPackageCompatibility(node.Key.Name, node.Key.Version, graph.Name));
+                var compatibilityData = GetCompatibilityData(graph, node.Key);
+                if (compatibilityData == null)
+                {
+                    continue;
+                }
+
+                if (!IsCompatible(compatibilityData))
+                {
+                    var issue = CompatibilityIssue.Incompatible(
+                        new PackageIdentity(node.Key.Name, node.Key.Version),
+                        graph.Framework,
+                        graph.RuntimeIdentifier);
+                    issues.Add(issue);
+                    _log.LogError(issue.Format());
+                }
+
+                // Check for matching ref/libs if we're checking a runtime-specific graph
+                var targetLibrary = compatibilityData.TargetLibrary;
+                if (!string.IsNullOrEmpty(graph.RuntimeIdentifier))
+                {
+                    // Scan the package for ref assemblies
+                    foreach (var compile in targetLibrary.CompileTimeAssemblies.Where(p => Path.GetExtension(p.Path).Equals(".dll", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        string name = Path.GetFileNameWithoutExtension(compile.Path);
+
+                        // If we haven't already started tracking this compile-time assembly, AND there isn't already a runtime-loadable version
+                        if (!compileAssemblies.ContainsKey(name) && !runtimeAssemblies.Contains(name))
+                        {
+                            // Track this assembly as potentially compile-time-only
+                            compileAssemblies.Add(name, node.Key);
+                        }
+                    }
+
+                    // Match up runtime assemblies
+                    foreach (var runtime in targetLibrary.RuntimeAssemblies.Where(p => Path.GetExtension(p.Path).Equals(".dll", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        string name = Path.GetFileNameWithoutExtension(runtime.Path);
+
+                        // If there was a compile-time-only assembly under this name...
+                        if (compileAssemblies.ContainsKey(name))
+                        {
+                            // Remove it, we've found a matching runtime ref
+                            compileAssemblies.Remove(name);
+                        }
+
+                        // Track this assembly as having a runtime assembly
+                        runtimeAssemblies.Add(name);
+                    }
+                }
+            }
+
+            // Generate errors for un-matched reference assemblies, if we're checking a runtime-specific graph
+            if (!string.IsNullOrEmpty(graph.RuntimeIdentifier))
+            {
+                foreach (var compile in compileAssemblies)
+                {
+                    var issue = CompatibilityIssue.ReferenceAssemblyNotImplemented(
+                        compile.Key,
+                        new PackageIdentity(compile.Value.Name, compile.Value.Version),
+                        graph.Framework,
+                        graph.RuntimeIdentifier);
+                    issues.Add(issue);
+                    _log.LogError(issue.Format());
+                }
+            }
+
+            return new CompatibilityCheckResult(graph, issues);
+        }
+
+        private bool IsCompatible(CompatibilityData compatibilityData)
+        {
+            // A package is compatible if it has...
+            return
+                compatibilityData.TargetLibrary.FrameworkAssemblies.Any() ||                        // Framework Assemblies, or
+                compatibilityData.TargetLibrary.CompileTimeAssemblies.Any() ||                      // Compile-time Assemblies, or
+                compatibilityData.TargetLibrary.RuntimeAssemblies.Any() ||                          // Runtime Assemblies, or
+                !compatibilityData.Files.Any(p => p.StartsWith("ref/") || p.StartsWith("lib/"));    // No assemblies at all (for any TxM)
+        }
+
+        private CompatibilityData GetCompatibilityData(RestoreTargetGraph graph, LibraryIdentity libraryId)
+        {
+            LockFileTargetLibrary targetLibrary = null;
+            var target = _lockFile.Targets.FirstOrDefault(t => Equals(t.TargetFramework, graph.Framework) && string.Equals(t.RuntimeIdentifier, graph.RuntimeIdentifier, StringComparison.Ordinal));
+            if (target != null)
+            {
+                targetLibrary = target.Libraries.FirstOrDefault(t => t.Name.Equals(libraryId.Name) && t.Version.Equals(libraryId.Version));
+            }
+
+            IEnumerable<string> files = null;
+            var lockFileLibrary = _lockFile.Libraries.FirstOrDefault(l => l.Name.Equals(libraryId.Name) && l.Version.Equals(libraryId.Version));
+            if (lockFileLibrary != null)
+            {
+                files = lockFileLibrary.Files;
+            }
+
+            if (files != null && targetLibrary != null)
+            {
+                // Everything we need is in the lock file!
+                return new CompatibilityData(lockFileLibrary.Files, targetLibrary);
+            }
+            else
+            {
+                // We need to generate some of the data. We'll need the local packge info to do that
+                var package = _localRepository.FindPackagesById(libraryId.Name)
+                    .FirstOrDefault(p => p.Version.Equals(libraryId.Version));
+                if (package == null)
+                {
+                    return null;
+                }
+
+                // Collect the file list if necessary
+                if (files == null)
+                {
+                    using (var nupkgStream = File.OpenRead(package.ZipPath))
+                    {
+                        var packageReader = new PackageReader(nupkgStream);
+                        files = packageReader
+                                .GetFiles()
+                                .Select(p => p.Replace(Path.DirectorySeparatorChar, '/'))
+                                .ToList();
+                    }
+                }
+
+                // Generate the target library if necessary
+                if (targetLibrary == null)
+                {
+                    targetLibrary = LockFileUtils.CreateLockFileTargetLibrary(
+                        package,
+                        graph,
+                        new VersionFolderPathResolver(_localRepository.RepositoryRoot),
+                        libraryId.Name);
+                }
+
+                return new CompatibilityData(files, targetLibrary);
+            }
+        }
+
+        private class CompatibilityData
+        {
+            public IEnumerable<string> Files { get; }
+            public LockFileTargetLibrary TargetLibrary { get; }
+
+            public CompatibilityData(IEnumerable<string> files, LockFileTargetLibrary targetLibrary)
+            {
+                Files = files;
+                TargetLibrary = targetLibrary;
+            }
+        }
+    }
+}

--- a/src/NuGet.Commands/LockFileUtils.cs
+++ b/src/NuGet.Commands/LockFileUtils.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.ContentModel;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.ProjectModel;
+using NuGet.Repositories;
+
+namespace NuGet.Commands
+{
+    internal static class LockFileUtils
+    {
+        public static LockFileTargetLibrary CreateLockFileTargetLibrary(LocalPackageInfo package, RestoreTargetGraph targetGraph, VersionFolderPathResolver defaultPackagePathResolver, string correctedPackageName)
+        {
+            var lockFileLib = new LockFileTargetLibrary();
+
+            var framework = targetGraph.Framework;
+            var runtimeIdentifier = targetGraph.RuntimeIdentifier;
+
+            // package.Id is read from nuspec and it might be in wrong casing.
+            // correctedPackageName should be the package name used by dependency graph and
+            // it has the correct casing that runtime needs during dependency resolution.
+            lockFileLib.Name = correctedPackageName ?? package.Id;
+            lockFileLib.Version = package.Version;
+
+            IList<string> files;
+            var contentItems = new ContentItemCollection();
+            HashSet<string> referenceFilter = null;
+            using (var nupkgStream = File.OpenRead(package.ZipPath))
+            {
+                var packageReader = new PackageReader(nupkgStream);
+                files = packageReader
+                    .GetFiles()
+                    .Select(p => p.Replace(Path.DirectorySeparatorChar, '/'))
+                    .ToList();
+
+                contentItems.Load(files);
+
+                var dependencySet = packageReader
+                    .GetPackageDependencies()
+                    .GetNearest(framework);
+                if (dependencySet != null)
+                {
+                    var set = dependencySet.Packages;
+
+                    if (set != null)
+                    {
+                        lockFileLib.Dependencies = set.ToList();
+                    }
+                }
+
+                var referenceSet = packageReader.GetReferenceItems().GetNearest(framework);
+                if (referenceSet != null)
+                {
+                    referenceFilter = new HashSet<string>(referenceSet.Items, StringComparer.OrdinalIgnoreCase);
+                }
+
+                // TODO: Remove this when we do #596
+                // ASP.NET Core isn't compatible with generic PCL profiles
+                if (!string.Equals(framework.Framework, FrameworkConstants.FrameworkIdentifiers.AspNetCore, StringComparison.OrdinalIgnoreCase)
+                    &&
+                    !string.Equals(framework.Framework, FrameworkConstants.FrameworkIdentifiers.DnxCore, StringComparison.OrdinalIgnoreCase))
+                {
+                    var frameworkAssemblies = packageReader.GetFrameworkItems().GetNearest(framework);
+                    if (frameworkAssemblies != null)
+                    {
+                        foreach (var assemblyReference in frameworkAssemblies.Items)
+                        {
+                            lockFileLib.FrameworkAssemblies.Add(assemblyReference);
+                        }
+                    }
+                }
+            }
+
+            var nativeCriteria = targetGraph.Conventions.Criteria.ForRuntime(targetGraph.RuntimeIdentifier);
+            var managedCriteria = targetGraph.Conventions.Criteria.ForFrameworkAndRuntime(framework, targetGraph.RuntimeIdentifier);
+
+            var compileGroup = contentItems.FindBestItemGroup(managedCriteria, targetGraph.Conventions.Patterns.CompileAssemblies, targetGraph.Conventions.Patterns.RuntimeAssemblies);
+
+            if (compileGroup != null)
+            {
+                lockFileLib.CompileTimeAssemblies = compileGroup.Items.Select(t => new LockFileItem(t.Path)).ToList();
+            }
+
+            var runtimeGroup = contentItems.FindBestItemGroup(managedCriteria, targetGraph.Conventions.Patterns.RuntimeAssemblies);
+            if (runtimeGroup != null)
+            {
+                lockFileLib.RuntimeAssemblies = runtimeGroup.Items.Select(p => new LockFileItem(p.Path)).ToList();
+            }
+
+            var resourceGroup = contentItems.FindBestItemGroup(managedCriteria, targetGraph.Conventions.Patterns.ResourceAssemblies);
+            if (resourceGroup != null)
+            {
+                lockFileLib.ResourceAssemblies = resourceGroup.Items.Select(ToResourceLockFileItem).ToList();
+            }
+
+            var nativeGroup = contentItems.FindBestItemGroup(nativeCriteria, targetGraph.Conventions.Patterns.NativeLibraries);
+            if (nativeGroup != null)
+            {
+                lockFileLib.NativeLibraries = nativeGroup.Items.Select(p => new LockFileItem(p.Path)).ToList();
+            }
+
+            // COMPAT: Support lib/contract so older packages can be consumed
+            var contractPath = "lib/contract/" + package.Id + ".dll";
+            var hasContract = files.Any(path => path == contractPath);
+            var hasLib = lockFileLib.RuntimeAssemblies.Any();
+
+            if (hasContract
+                && hasLib
+                && !framework.IsDesktop())
+            {
+                lockFileLib.CompileTimeAssemblies.Clear();
+                lockFileLib.CompileTimeAssemblies.Add(new LockFileItem(contractPath));
+            }
+
+            // Apply filters from the <references> node in the nuspec
+            if (referenceFilter != null)
+            {
+                // Remove anything that starts with "lib/" and is NOT specified in the reference filter.
+                // runtimes/* is unaffected (it doesn't start with lib/)
+                lockFileLib.RuntimeAssemblies = lockFileLib.RuntimeAssemblies.Where(p => !p.Path.StartsWith("lib/") || referenceFilter.Contains(p.Path)).ToList();
+                lockFileLib.CompileTimeAssemblies = lockFileLib.CompileTimeAssemblies.Where(p => !p.Path.StartsWith("lib/") || referenceFilter.Contains(p.Path)).ToList();
+            }
+
+            return lockFileLib;
+        }
+
+        private static bool HasItems(ContentItemGroup compileGroup)
+        {
+            return (compileGroup != null && compileGroup.Items.Any());
+        }
+
+        private static LockFileItem ToResourceLockFileItem(ContentItem item)
+        {
+            return new LockFileItem(item.Path)
+            {
+                Properties =
+                {
+                    { "locale", item.Properties["locale"].ToString()}
+                }
+            };
+        }
+
+    }
+}

--- a/src/NuGet.Commands/NuGet.Commands.xproj
+++ b/src/NuGet.Commands/NuGet.Commands.xproj
@@ -7,9 +7,12 @@
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>567e8582-0e73-4a34-a7d3-ed9486415523</ProjectGuid>
-    <RootNamespace>NuGet.Strawman.Commands</RootNamespace>
+    <RootNamespace>NuGet.Commands</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <AssemblyName>NuGet.Commands</AssemblyName>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/NuGet.Commands/Properties/Strings.Designer.cs
+++ b/src/NuGet.Commands/Properties/Strings.Designer.cs
@@ -11,6 +11,38 @@ namespace NuGet.Commands
             = new ResourceManager("NuGet.Commands.Strings", typeof(Strings).GetTypeInfo().Assembly);
 
         /// <summary>
+        /// Checking compatibility of packages on {0}.
+        /// </summary>
+        internal static string Log_CheckingCompatibility
+        {
+            get { return GetString("Log_CheckingCompatibility"); }
+        }
+
+        /// <summary>
+        /// Checking compatibility of packages on {0}.
+        /// </summary>
+        internal static string FormatLog_CheckingCompatibility(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Log_CheckingCompatibility"), p0);
+        }
+
+        /// <summary>
+        /// Checking compatibility for {0} {1} with {2}.
+        /// </summary>
+        internal static string Log_CheckingPackageCompatibility
+        {
+            get { return GetString("Log_CheckingPackageCompatibility"); }
+        }
+
+        /// <summary>
+        /// Checking compatibility for {0} {1} with {2}.
+        /// </summary>
+        internal static string FormatLog_CheckingPackageCompatibility(object p0, object p1, object p2)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Log_CheckingPackageCompatibility"), p0, p1, p2);
+        }
+
+        /// <summary>
         /// Failed to resolve conflicts.
         /// </summary>
         internal static string Log_FailedToResolveConflicts
@@ -75,6 +107,86 @@ namespace NuGet.Commands
         }
 
         /// <summary>
+        /// {0} {1} provides a compile-time reference assembly for {2} on {3}, but there is no compatible run-time assembly.
+        /// </summary>
+        internal static string Log_MissingImplementationFx
+        {
+            get { return GetString("Log_MissingImplementationFx"); }
+        }
+
+        /// <summary>
+        /// {0} {1} provides a compile-time reference assembly for {2} on {3}, but there is no compatible run-time assembly.
+        /// </summary>
+        internal static string FormatLog_MissingImplementationFx(object p0, object p1, object p2, object p3)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Log_MissingImplementationFx"), p0, p1, p2, p3);
+        }
+
+        /// <summary>
+        /// {0} {1} provides a compile-time reference assembly for {2} on {3}, but there is no run-time assembly compatible with {4}.
+        /// </summary>
+        internal static string Log_MissingImplementationFxRuntime
+        {
+            get { return GetString("Log_MissingImplementationFxRuntime"); }
+        }
+
+        /// <summary>
+        /// {0} {1} provides a compile-time reference assembly for {2} on {3}, but there is no run-time assembly compatible with {4}.
+        /// </summary>
+        internal static string FormatLog_MissingImplementationFxRuntime(object p0, object p1, object p2, object p3, object p4)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Log_MissingImplementationFxRuntime"), p0, p1, p2, p3, p4);
+        }
+
+        /// <summary>
+        /// {0} {1} is not compatible with {2}.
+        /// </summary>
+        internal static string Log_PackageNotCompatibleWithFx
+        {
+            get { return GetString("Log_PackageNotCompatibleWithFx"); }
+        }
+
+        /// <summary>
+        /// {0} {1} is not compatible with {2}.
+        /// </summary>
+        internal static string FormatLog_PackageNotCompatibleWithFx(object p0, object p1, object p2)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Log_PackageNotCompatibleWithFx"), p0, p1, p2);
+        }
+
+        /// <summary>
+        /// All packages are compatibile with {0}.
+        /// </summary>
+        internal static string Log_PackagesAreCompatible
+        {
+            get { return GetString("Log_PackagesAreCompatible"); }
+        }
+
+        /// <summary>
+        /// All packages are compatibile with {0}.
+        /// </summary>
+        internal static string FormatLog_PackagesAreCompatible(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Log_PackagesAreCompatible"), p0);
+        }
+
+        /// <summary>
+        /// Some packages are not compatible with {0}.
+        /// </summary>
+        internal static string Log_PackagesIncompatible
+        {
+            get { return GetString("Log_PackagesIncompatible"); }
+        }
+
+        /// <summary>
+        /// Some packages are not compatible with {0}.
+        /// </summary>
+        internal static string FormatLog_PackagesIncompatible(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Log_PackagesIncompatible"), p0);
+        }
+
+        /// <summary>
         /// The project does not specify any target frameworks.
         /// </summary>
         internal static string Log_ProjectDoesNotSpecifyTargetFrameworks
@@ -91,19 +203,19 @@ namespace NuGet.Commands
         }
 
         /// <summary>
-        /// Resolving conflicts for framework {0}.
+        /// Resolving conflicts for {0}...
         /// </summary>
-        internal static string Log_ResolvingConflictsForFramework
+        internal static string Log_ResolvingConflicts
         {
-            get { return GetString("Log_ResolvingConflictsForFramework"); }
+            get { return GetString("Log_ResolvingConflicts"); }
         }
 
         /// <summary>
-        /// Resolving conflicts for framework {0}.
+        /// Resolving conflicts for {0}...
         /// </summary>
-        internal static string FormatLog_ResolvingConflictsForFramework(object p0)
+        internal static string FormatLog_ResolvingConflicts(object p0)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("Log_ResolvingConflictsForFramework"), p0);
+            return string.Format(CultureInfo.CurrentCulture, GetString("Log_ResolvingConflicts"), p0);
         }
 
         /// <summary>
@@ -120,38 +232,6 @@ namespace NuGet.Commands
         internal static string FormatLog_RestoringPackages(object p0)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("Log_RestoringPackages"), p0);
-        }
-
-        /// <summary>
-        /// Restoring packages for framework {0}.
-        /// </summary>
-        internal static string Log_RestoringPackagesForFramework
-        {
-            get { return GetString("Log_RestoringPackagesForFramework"); }
-        }
-
-        /// <summary>
-        /// Restoring packages for framework {0}.
-        /// </summary>
-        internal static string FormatLog_RestoringPackagesForFramework(object p0)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("Log_RestoringPackagesForFramework"), p0);
-        }
-
-        /// <summary>
-        /// Restoring packages for framework {0} on {1}.
-        /// </summary>
-        internal static string Log_RestoringPackagesForFrameworkAndRuntime
-        {
-            get { return GetString("Log_RestoringPackagesForFrameworkAndRuntime"); }
-        }
-
-        /// <summary>
-        /// Restoring packages for framework {0} on {1}.
-        /// </summary>
-        internal static string FormatLog_RestoringPackagesForFrameworkAndRuntime(object p0, object p1)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("Log_RestoringPackagesForFrameworkAndRuntime"), p0, p1);
         }
 
         /// <summary>

--- a/src/NuGet.Commands/RestoreRequest.cs
+++ b/src/NuGet.Commands/RestoreRequest.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Configuration;
+using NuGet.Frameworks;
 using NuGet.ProjectModel;
 
 namespace NuGet.Commands
@@ -17,8 +19,10 @@ namespace NuGet.Commands
             Project = project;
             Sources = sources.ToList().AsReadOnly();
             PackagesDirectory = packagesDirectory;
-            ExternalProjects = new List<ExternalProjectReference>();
             WriteMSBuildFiles = true;
+
+            ExternalProjects = new List<ExternalProjectReference>();
+            SupportProfiles = new List<Tuple<NuGetFramework, string>>();
         }
 
         /// <summary>
@@ -63,5 +67,8 @@ namespace NuGet.Commands
         /// If set, MSBuild files (.targets/.props) will be written for the project being restored
         /// </summary>
         public bool WriteMSBuildFiles { get; set; }
+
+        // Temporary; we'll get this from the project eventually.
+        public IList<Tuple<NuGetFramework, string>> SupportProfiles { get; }
     }
 }

--- a/src/NuGet.Commands/RestoreResult.cs
+++ b/src/NuGet.Commands/RestoreResult.cs
@@ -17,6 +17,8 @@ namespace NuGet.Commands
         /// </summary>
         public IEnumerable<RestoreTargetGraph> RestoreGraphs { get; }
 
+        public IEnumerable<CompatibilityCheckResult> CompatibilityCheckResults { get; }
+
         /// <summary>
         /// Gets the lock file that was generated during the restore or, in the case of a locked lock file,
         /// was used to determine the packages to install during the restore.
@@ -27,14 +29,15 @@ namespace NuGet.Commands
         public LockFile LockFile { get; }
 
         public RestoreResult(bool success, IEnumerable<RestoreTargetGraph> restoreGraphs)
-            : this(success, restoreGraphs, lockfile: null)
+            : this(success, restoreGraphs, Enumerable.Empty<CompatibilityCheckResult>(), lockfile: null)
         {
         }
 
-        public RestoreResult(bool success, IEnumerable<RestoreTargetGraph> restoreGraphs, LockFile lockfile)
+        public RestoreResult(bool success, IEnumerable<RestoreTargetGraph> restoreGraphs, IEnumerable<CompatibilityCheckResult> compatibilityCheckResults, LockFile lockfile)
         {
             Success = success;
             RestoreGraphs = restoreGraphs;
+            CompatibilityCheckResults = compatibilityCheckResults;
             LockFile = lockfile;
         }
 

--- a/src/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Commands/Strings.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Log_CheckingCompatibility" xml:space="preserve">
+    <value>Checking compatibility of packages on {0}.</value>
+  </data>
+  <data name="Log_CheckingPackageCompatibility" xml:space="preserve">
+    <value>Checking compatibility for {0} {1} with {2}.</value>
+  </data>
   <data name="Log_FailedToResolveConflicts" xml:space="preserve">
     <value>Failed to resolve conflicts.</value>
   </data>
@@ -129,20 +135,29 @@
   <data name="Log_MergingRuntimes" xml:space="preserve">
     <value>Merging in runtimes defined in {0}.</value>
   </data>
+  <data name="Log_MissingImplementationFx" xml:space="preserve">
+    <value>{0} {1} provides a compile-time reference assembly for {2} on {3}, but there is no compatible run-time assembly.</value>
+  </data>
+  <data name="Log_MissingImplementationFxRuntime" xml:space="preserve">
+    <value>{0} {1} provides a compile-time reference assembly for {2} on {3}, but there is no run-time assembly compatible with {4}.</value>
+  </data>
+  <data name="Log_PackageNotCompatibleWithFx" xml:space="preserve">
+    <value>{0} {1} is not compatible with {2}.</value>
+  </data>
+  <data name="Log_PackagesAreCompatible" xml:space="preserve">
+    <value>All packages are compatibile with {0}.</value>
+  </data>
+  <data name="Log_PackagesIncompatible" xml:space="preserve">
+    <value>Some packages are not compatible with {0}.</value>
+  </data>
   <data name="Log_ProjectDoesNotSpecifyTargetFrameworks" xml:space="preserve">
     <value>The project does not specify any target frameworks.</value>
   </data>
-  <data name="Log_ResolvingConflictsForFramework" xml:space="preserve">
-    <value>Resolving conflicts for framework {0}.</value>
+  <data name="Log_ResolvingConflicts" xml:space="preserve">
+    <value>Resolving conflicts for {0}...</value>
   </data>
   <data name="Log_RestoringPackages" xml:space="preserve">
     <value>Restoring packages for {0}...</value>
-  </data>
-  <data name="Log_RestoringPackagesForFramework" xml:space="preserve">
-    <value>Restoring packages for framework {0}.</value>
-  </data>
-  <data name="Log_RestoringPackagesForFrameworkAndRuntime" xml:space="preserve">
-    <value>Restoring packages for framework {0} on {1}.</value>
   </data>
   <data name="Log_ScanningForRuntimeJson" xml:space="preserve">
     <value>Scanning packages for runtime.json files...</value>

--- a/src/NuGet.ContentModel/ContentItemCollection.cs
+++ b/src/NuGet.ContentModel/ContentItemCollection.cs
@@ -77,6 +77,11 @@ namespace NuGet.ContentModel
             }
         }
 
+        public bool HasItemGroup(SelectionCriteria criteria, params PatternSet[] definitions)
+        {
+            return FindBestItemGroup(criteria, definitions) != null;
+        }
+
         public ContentItemGroup FindBestItemGroup(SelectionCriteria criteria, params PatternSet[] definitions)
         {
             foreach (var definition in definitions)

--- a/src/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Frameworks/FrameworkConstants.cs
@@ -72,6 +72,10 @@ namespace NuGet.Frameworks
             public static readonly NuGetFramework Net452 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 5, 2, 0));
             public static readonly NuGetFramework Net46 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 6, 0, 0));
 
+            public static readonly NuGetFramework NetCore45 = new NuGetFramework(FrameworkIdentifiers.NetCore, new Version(4, 5, 0, 0));
+            public static readonly NuGetFramework NetCore451 = new NuGetFramework(FrameworkIdentifiers.NetCore, new Version(4, 5, 1, 0));
+            public static readonly NuGetFramework NetCore50 = new NuGetFramework(FrameworkIdentifiers.NetCore, new Version(5, 0, 0, 0));
+
             public static readonly NuGetFramework Win8 = new NuGetFramework(FrameworkIdentifiers.Windows, new Version(8, 0, 0, 0));
             public static readonly NuGetFramework Win81 = new NuGetFramework(FrameworkIdentifiers.Windows, new Version(8, 1, 0, 0));
             public static readonly NuGetFramework Win10 = new NuGetFramework(FrameworkIdentifiers.Windows, new Version(10, 0, 0, 0));

--- a/src/NuGet.ProjectModel/HashCodeCombiner.cs
+++ b/src/NuGet.ProjectModel/HashCodeCombiner.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.ProjectModel
+{
+    /// <summary>
+    /// Hash code creator, based on the original NuGet hash code combiner/ASP hash code combiner implementations
+    /// </summary>
+    internal sealed class HashCodeCombiner
+    {
+        // seed from String.GetHashCode()
+        private const long Seed = 0x1505L;
+
+        private long _combinedHash;
+
+        internal HashCodeCombiner()
+        {
+            _combinedHash = Seed;
+        }
+
+        internal int CombinedHash
+        {
+            get { return _combinedHash.GetHashCode(); }
+        }
+
+        internal void AddInt32(int i)
+        {
+            _combinedHash = ((_combinedHash << 5) + _combinedHash) ^ i;
+        }
+
+        internal void AddObject(int i)
+        {
+            AddInt32(i);
+        }
+
+        internal void AddObject(bool b)
+        {
+            AddInt32(b.GetHashCode());
+        }
+
+        internal void AddObject(object o)
+        {
+            if (o != null)
+            {
+                AddInt32(o.GetHashCode());
+            }
+        }
+
+        internal void AddStringIgnoreCase(string s)
+        {
+            if (s != null)
+            {
+                AddInt32(s.ToUpperInvariant().GetHashCode());
+            }
+        }
+
+        /// <summary>
+        /// Create a unique hash code for the given set of items
+        /// </summary>
+        internal static int GetHashCode(params object[] objects)
+        {
+            var combiner = new HashCodeCombiner();
+
+            foreach (var obj in objects)
+            {
+                combiner.AddObject(obj);
+            }
+
+            return combiner.CombinedHash;
+        }
+    }
+}

--- a/test/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -8,7 +8,9 @@ using Newtonsoft.Json.Linq;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
+using NuGet.RuntimeModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Xunit;
@@ -23,9 +25,6 @@ namespace NuGet.Commands.Test
         public async Task RestoreCommand_NuGetVersioning107RuntimeAssemblies()
         {
             // Arrange
-            var logger = new TestLogger();
-            var command = new RestoreCommand(logger);
-
             var sources = new List<PackageSource>();
             sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
             var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
@@ -45,7 +44,9 @@ namespace NuGet.Commands.Test
             var lockFileFormat = new LockFileFormat();
 
             // Act
-            var result = await command.ExecuteAsync(request);
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger, request);
+            var result = await command.ExecuteAsync();
             var installed = result.GetAllInstalled();
             var unresolved = result.GetAllUnresolved();
             var runtimeAssemblies = GetRuntimeAssemblies(result.LockFile.Targets, "netcore50", null);
@@ -67,9 +68,6 @@ namespace NuGet.Commands.Test
         public async Task RestoreCommand_InstallPackageWithDependencies()
         {
             // Arrange
-            var logger = new TestLogger();
-            var command = new RestoreCommand(logger);
-
             var sources = new List<PackageSource>();
             sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
             var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
@@ -89,7 +87,9 @@ namespace NuGet.Commands.Test
             var lockFileFormat = new LockFileFormat();
 
             // Act
-            var result = await command.ExecuteAsync(request);
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger, request);
+            var result = await command.ExecuteAsync();
             var installed = result.GetAllInstalled();
             var unresolved = result.GetAllUnresolved();
             var runtimeAssemblies = GetRuntimeAssemblies(result.LockFile.Targets, "netcore50", null);
@@ -97,7 +97,7 @@ namespace NuGet.Commands.Test
             var jsonNetPackage = installed.SingleOrDefault(package => package.Name == "Newtonsoft.Json");
 
             // Assert
-            Assert.Equal(0, logger.Errors);
+            Assert.Equal(9, logger.Errors); // There will be compatibility errors, but we don't care
             Assert.Equal(3, installed.Count);
             Assert.Equal(0, unresolved.Count);
             Assert.Equal("5.0.4", jsonNetPackage.Version.ToNormalizedString());
@@ -110,9 +110,6 @@ namespace NuGet.Commands.Test
         public async Task RestoreCommand_RestoreWithNoChanges()
         {
             // Arrange
-            var logger = new TestLogger();
-            var command = new RestoreCommand(logger);
-
             var sources = new List<PackageSource>();
             sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
             var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
@@ -129,10 +126,13 @@ namespace NuGet.Commands.Test
             request.MaxDegreeOfConcurrency = 1;
             request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
-            var firstRun = await command.ExecuteAsync(request);
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger, request);
+            var firstRun = await command.ExecuteAsync();
 
             // Act
-            var result = await command.ExecuteAsync(request);
+            command = new RestoreCommand(logger, request);
+            var result = await command.ExecuteAsync();
             var installed = result.GetAllInstalled();
             var unresolved = result.GetAllUnresolved();
 
@@ -148,9 +148,6 @@ namespace NuGet.Commands.Test
         public async Task RestoreCommand_PackageIsAddedToPackageCache(string source)
         {
             // Arrange
-            var logger = new TestLogger();
-            var command = new RestoreCommand(logger);
-
             var sources = new List<PackageSource>();
             sources.Add(new PackageSource(source));
             var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
@@ -168,7 +165,9 @@ namespace NuGet.Commands.Test
             request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
             // Act
-            var result = await command.ExecuteAsync(request);
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger, request);
+            var result = await command.ExecuteAsync();
             var nuspecPath = Path.Combine(packagesDir, "NuGet.Versioning", "1.0.7", "NuGet.Versioning.nuspec");
 
             // Assert
@@ -182,9 +181,6 @@ namespace NuGet.Commands.Test
         public async Task RestoreCommand_PackagesAreExtractedToTheNormalizedPath(string source)
         {
             // Arrange
-            var logger = new TestLogger();
-            var command = new RestoreCommand(logger);
-
             var sources = new List<PackageSource>();
             sources.Add(new PackageSource(source));
             var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
@@ -202,7 +198,9 @@ namespace NuGet.Commands.Test
             request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
             // Act
-            var result = await command.ExecuteAsync(request);
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger, request);
+            var result = await command.ExecuteAsync();
             var nuspecPath = Path.Combine(packagesDir, "owin", "1.0.0", "owin.nuspec");
 
             // Assert
@@ -213,9 +211,6 @@ namespace NuGet.Commands.Test
         public async Task RestoreCommand_JsonNet701Beta3RuntimeAssemblies()
         {
             // Arrange
-            var logger = new TestLogger();
-            var command = new RestoreCommand(logger);
-
             var sources = new List<PackageSource>();
             sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
             var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
@@ -235,7 +230,9 @@ namespace NuGet.Commands.Test
             var lockFileFormat = new LockFileFormat();
 
             // Act
-            var result = await command.ExecuteAsync(request);
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger, request);
+            var result = await command.ExecuteAsync();
             var installed = result.GetAllInstalled();
             var unresolved = result.GetAllUnresolved();
             var runtimeAssemblies = GetRuntimeAssemblies(result.LockFile.Targets, "netcore50", null);
@@ -257,9 +254,6 @@ namespace NuGet.Commands.Test
         public async Task RestoreCommand_NoCompatibleRuntimeAssembliesForProject()
         {
             // Arrange
-            var logger = new TestLogger();
-            var command = new RestoreCommand(logger);
-
             var sources = new List<PackageSource>();
             sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
             var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
@@ -279,7 +273,9 @@ namespace NuGet.Commands.Test
             var lockFileFormat = new LockFileFormat();
 
             // Act
-            var result = await command.ExecuteAsync(request);
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger, request);
+            var result = await command.ExecuteAsync();
             var installed = result.GetAllInstalled();
             var unresolved = result.GetAllUnresolved();
             var runtimeAssemblies = GetRuntimeAssemblies(result.LockFile.Targets, "netcore50", null);
@@ -287,7 +283,13 @@ namespace NuGet.Commands.Test
             var runtimeAssembly = runtimeAssemblies.FirstOrDefault();
 
             // Assert
-            Assert.Equal(0, logger.Errors);
+            var expectedIssue = CompatibilityIssue.Incompatible(
+                new PackageIdentity("NuGet.Core", new NuGetVersion(2, 8, 3)), FrameworkConstants.CommonFrameworks.NetCore50, null);
+            Assert.Contains(expectedIssue, result.CompatibilityCheckResults.SelectMany(c => c.Issues).ToArray());
+            Assert.False(result.CompatibilityCheckResults.Any(c => c.Success));
+            Assert.Contains(expectedIssue.Format(), logger.Messages);
+
+            Assert.Equal(9, logger.Errors);
             Assert.Equal(2, installed.Count);
             Assert.Equal(0, unresolved.Count);
             Assert.Equal(0, runtimeAssemblies.Count);
@@ -296,10 +298,20 @@ namespace NuGet.Commands.Test
         private static List<LockFileItem> GetRuntimeAssemblies(IList<LockFileTarget> targets, string framework, string runtime)
         {
             return targets.Where(target => target.TargetFramework.Equals(NuGetFramework.Parse(framework)))
-            .Where(target => target.RuntimeIdentifier == runtime)
-            .SelectMany(target => target.Libraries)
-            .SelectMany(library => library.RuntimeAssemblies)
-            .ToList();
+                .Where(target => target.RuntimeIdentifier == runtime)
+                .SelectMany(target => target.Libraries)
+                .SelectMany(library => library.RuntimeAssemblies)
+                .ToList();
+        }
+
+        private static void AddRuntime(PackageSpec spec, string rid)
+        {
+            spec.RuntimeGraph = RuntimeGraph.Merge(
+                spec.RuntimeGraph,
+                new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription(rid)
+                }));
         }
 
         private static void AddDependency(PackageSpec spec, string id, string version)

--- a/test/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
+++ b/test/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using NuGet.Frameworks;
 using Xunit;
 


### PR DESCRIPTION
Adds PCL guardrails. Note: **currently does NOT support reading the `supports` data from the project.json**

To test it, go to `misc\RestoreTests\SupportsTest` and run `..\..\..\nuget3 restore`. You should see the `dnxcore50` restore work and the `sl40` restore fail. There is a partial example of PCL guardrails (refs without matching libs, etc.) in `misc\RestoreTests\PclExample` but it requires packages that contain `ref/dotnet` folders and such. To test a project against a "supports profile" (i.e. a TxM, RID pair you want to test restore against) you must specify it in the `--supports txm~rid` switch to nuget3 restore. For example `nuget3 restore --source <source of CLR packages> --supports netcore50~win8-aot`.

I will be adding the project.json integration shortly but I wanted to get the algorithm testable first :)

/cc @emgarten @lodejard @davidfowl @yishaigalatzer  @ericstj
