### PR TITLE
Add support for reading PCL compatibility profiles from project.json

### DIFF
--- a/misc/RestoreTests/PclExample/project.json
+++ b/misc/RestoreTests/PclExample/project.json
@@ -1,13 +1,19 @@
 {
     "dependencies": {
         "System.Linq": "4.0.0-beta-*",
-        "Microsoft.NETCore.Targets": "1.0.0-beta-*"
+        "Microsoft.NETCore.Targets": "1.0.0-beta-*",
+
+        "System.Reflection": "4.0.10-beta-*",
+        "System.Globalization": "4.0.10-beta-*",
+        "System.IO": "4.0.10-beta-*",
+        "System.Text.Encoding": "4.0.10-beta-*",
+        "System.Threading.Tasks": "4.0.10-beta-*",
     },
     "frameworks": {
         "dotnet": {}
     },
     "supports": {
-        "net46.app": {
-        }
+        "dnxcore50.app": {},
+        "net46.app": {}
     }
 }

--- a/misc/RestoreTests/PclExample/project.json
+++ b/misc/RestoreTests/PclExample/project.json
@@ -1,13 +1,17 @@
 {
     "dependencies": {
         "System.Linq": "4.0.0-beta-*",
-        "Microsoft.NETCore.Targets": "1.0.0-beta-*"
+        "Microsoft.NETCore.Targets": "1.0.0-beta-*",
     },
     "frameworks": {
-        "core50": {}
+        "dotnet": {}
     },
     "supports": {
-        "netcore50": ["win8-x86", "win8-x64"],
-        "dnxcore50": []
+        "woozlewuzzle.app": {},
+        "silverlight.app": {
+            "sl40": ""
+        },
+        "net46.app": {},
+        "dnxcore50.app": {}
     }
 }

--- a/misc/RestoreTests/PclExample/project.json
+++ b/misc/RestoreTests/PclExample/project.json
@@ -1,17 +1,13 @@
 {
     "dependencies": {
         "System.Linq": "4.0.0-beta-*",
-        "Microsoft.NETCore.Targets": "1.0.0-beta-*",
+        "Microsoft.NETCore.Targets": "1.0.0-beta-*"
     },
     "frameworks": {
         "dotnet": {}
     },
     "supports": {
-        "woozlewuzzle.app": {},
-        "silverlight.app": {
-            "sl40": ""
-        },
-        "net46.app": {},
-        "dnxcore50.app": {}
+        "net46.app": {
+        }
     }
 }

--- a/src/NuGet.CommandLine/Program.cs
+++ b/src/NuGet.CommandLine/Program.cs
@@ -115,13 +115,17 @@ namespace NuGet.CommandLine
                             {
                                 var supportsProfiles = supports.Values.Select(s =>
                                 {
+                                    if(!s.Contains("~"))
+                                    {
+                                        return new FrameworkRuntimePair(NuGetFramework.Parse(s), null);
+                                    }
                                     var splat = s.Split('~');
-                                    return Tuple.Create(NuGetFramework.Parse(splat[0]), splat[1]);
+                                    return new FrameworkRuntimePair(NuGetFramework.Parse(splat[0]), splat[1]);
                                 });
 
                                 foreach (var profile in supportsProfiles)
                                 {
-                                    request.SupportProfiles.Add(profile);
+                                    request.CompatibilityProfiles.Add(profile);
                                 }
                             }
 

--- a/src/NuGet.Commands/CompatibilityIssue.cs
+++ b/src/NuGet.Commands/CompatibilityIssue.cs
@@ -51,7 +51,7 @@ namespace NuGet.Commands
                     }
                     return Strings.FormatLog_MissingImplementationFxRuntime(Package.Id, Package.Version, AssemblyName, Framework, RuntimeIdentifier);
                 case CompatibilityIssueType.PackageIncompatible:
-                    return Strings.FormatLog_PackageNotCompatibleWithFx(Package.Id, Package.Version, RestoreTargetGraph.GetName(Framework, RuntimeIdentifier));
+                    return Strings.FormatLog_PackageNotCompatibleWithFx(Package.Id, Package.Version, FrameworkRuntimePair.GetName(Framework, RuntimeIdentifier));
                 default:
                     return null;
             }

--- a/src/NuGet.Commands/CompatilibityChecker.cs
+++ b/src/NuGet.Commands/CompatilibityChecker.cs
@@ -50,7 +50,6 @@ namespace NuGet.Commands
             // * All combinations of TxMs and Runtimes defined in the project.json
             // * Additional (TxMs, Runtime) pairs defined by the "supports" mechanism in project.json
 
-
             var runtimeAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var compileAssemblies = new Dictionary<string, LibraryIdentity>(StringComparer.OrdinalIgnoreCase);
             var issues = new List<CompatibilityIssue>();

--- a/src/NuGet.Commands/Properties/Strings.Designer.cs
+++ b/src/NuGet.Commands/Properties/Strings.Designer.cs
@@ -235,6 +235,22 @@ namespace NuGet.Commands
         }
 
         /// <summary>
+        /// Restoring packages for {0} to determine compatibility...
+        /// </summary>
+        internal static string Log_RestoringPackagesForCompat
+        {
+            get { return GetString("Log_RestoringPackagesForCompat"); }
+        }
+
+        /// <summary>
+        /// Restoring packages for {0} to determine compatibility...
+        /// </summary>
+        internal static string FormatLog_RestoringPackagesForCompat(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Log_RestoringPackagesForCompat"), p0);
+        }
+
+        /// <summary>
         /// Scanning packages for runtime.json files...
         /// </summary>
         internal static string Log_ScanningForRuntimeJson
@@ -280,6 +296,22 @@ namespace NuGet.Commands
         internal static string FormatLog_UnresolvedDependency(object p0, object p1, object p2)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("Log_UnresolvedDependency"), p0, p1, p2);
+        }
+
+        /// <summary>
+        /// Unknown Compatibility Profile: {0}
+        /// </summary>
+        internal static string Log_UnknownCompatibilityProfile
+        {
+            get { return GetString("Log_UnknownCompatibilityProfile"); }
+        }
+
+        /// <summary>
+        /// Unknown Compatibility Profile: {0}
+        /// </summary>
+        internal static string FormatLog_UnknownCompatibilityProfile(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Log_UnknownCompatibilityProfile"), p0);
         }
 
         /// <summary>

--- a/src/NuGet.Commands/Properties/Strings.Designer.cs
+++ b/src/NuGet.Commands/Properties/Strings.Designer.cs
@@ -346,6 +346,38 @@ namespace NuGet.Commands
             return GetString("MSBuildWarning_MultiTarget");
         }
 
+        /// <summary>
+        /// Unable to satisfy conflicting requests for '{0}': {1}
+        /// </summary>
+        internal static string Log_ResolverConflict
+        {
+            get { return GetString("Log_ResolverConflict"); }
+        }
+
+        /// <summary>
+        /// Unable to satisfy conflicting requests for '{0}': {1}
+        /// </summary>
+        internal static string FormatLog_ResolverConflict(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Log_ResolverConflict"), p0, p1);
+        }
+
+        /// <summary>
+        /// {0} (via {1})
+        /// </summary>
+        internal static string ResolverRequest_ToStringFormat
+        {
+            get { return GetString("ResolverRequest_ToStringFormat"); }
+        }
+
+        /// <summary>
+        /// {0} (via {1})
+        /// </summary>
+        internal static string FormatResolverRequest_ToStringFormat(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ResolverRequest_ToStringFormat"), p0, p1);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/NuGet.Commands/ResolverConflict.cs
+++ b/src/NuGet.Commands/ResolverConflict.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NuGet.LibraryModel;
+
+namespace NuGet.Commands
+{
+    public class ResolverConflict
+    {
+        public string Name { get; }
+        public IList<ResolverRequest> Requests { get; }
+
+        public ResolverConflict(string name, IEnumerable<ResolverRequest> requests)
+        {
+            Name = name;
+            Requests = requests.ToList();
+        }
+    }
+}

--- a/src/NuGet.Commands/ResolverRequest.cs
+++ b/src/NuGet.Commands/ResolverRequest.cs
@@ -1,0 +1,21 @@
+﻿using NuGet.LibraryModel;
+
+namespace NuGet.Commands
+{
+    public class ResolverRequest
+    {
+        public LibraryIdentity Requestor { get; }
+        public LibraryRange Request { get; }
+
+        public ResolverRequest(LibraryIdentity requestor, LibraryRange request)
+        {
+            Requestor = requestor;
+            Request = request;
+        }
+
+        public override string ToString()
+        {
+            return Strings.FormatResolverRequest_ToStringFormat(Request.ToString(), Requestor.ToString());
+        }
+    }
+}

--- a/src/NuGet.Commands/RestoreGraph.cs
+++ b/src/NuGet.Commands/RestoreGraph.cs
@@ -55,25 +55,13 @@ namespace NuGet.Commands
             RuntimeGraph = runtimeGraph;
             Framework = framework;
             Graph = graph;
-            Name = GetName(Framework, RuntimeIdentifier);
+            Name = FrameworkRuntimePair.GetName(Framework, RuntimeIdentifier);
 
             Conventions = new ManagedCodeConventions(runtimeGraph);
 
             Install = install;
             Flattened = flattened;
             Unresolved = unresolved;
-        }
-
-        public static string GetName(NuGetFramework framework, string runtimeIdentifier)
-        {
-            if (string.IsNullOrEmpty(runtimeIdentifier))
-            {
-                return framework.ToString();
-            }
-            else
-            {
-                return $"{framework} ({runtimeIdentifier})";
-            }
         }
 
         public static RestoreTargetGraph Create(bool inConflict, bool writeToLockFile, NuGetFramework framework, GraphNode<RemoteResolveResult> graph, RemoteWalkContext context, ILogger logger)

--- a/src/NuGet.Commands/RestoreRequest.cs
+++ b/src/NuGet.Commands/RestoreRequest.cs
@@ -22,7 +22,7 @@ namespace NuGet.Commands
             WriteMSBuildFiles = true;
 
             ExternalProjects = new List<ExternalProjectReference>();
-            SupportProfiles = new List<Tuple<NuGetFramework, string>>();
+            CompatibilityProfiles = new HashSet<FrameworkRuntimePair>();
         }
 
         /// <summary>
@@ -68,7 +68,9 @@ namespace NuGet.Commands
         /// </summary>
         public bool WriteMSBuildFiles { get; set; }
 
-        // Temporary; we'll get this from the project eventually.
-        public IList<Tuple<NuGetFramework, string>> SupportProfiles { get; }
+        /// <summary>
+        /// Additional compatibility profiles to check compatibility with.
+        /// </summary>
+        public ISet<FrameworkRuntimePair> CompatibilityProfiles { get; }
     }
 }

--- a/src/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Commands/Strings.resx
@@ -159,6 +159,9 @@
   <data name="Log_RestoringPackages" xml:space="preserve">
     <value>Restoring packages for {0}...</value>
   </data>
+  <data name="Log_RestoringPackagesForCompat" xml:space="preserve">
+    <value>Restoring packages for {0} to determine compatibility...</value>
+  </data>
   <data name="Log_ScanningForRuntimeJson" xml:space="preserve">
     <value>Scanning packages for runtime.json files...</value>
   </data>
@@ -167,6 +170,9 @@
   </data>
   <data name="Log_UnresolvedDependency" xml:space="preserve">
     <value>Unable to resolve {0} {1} for {2}.</value>
+  </data>
+  <data name="Log_UnknownCompatibilityProfile" xml:space="preserve">
+    <value>Unknown Compatibility Profile: {0}</value>
   </data>
   <data name="Log_UsingSource" xml:space="preserve">
     <value>Using source {0}.</value>

--- a/src/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Commands/Strings.resx
@@ -180,4 +180,10 @@
   <data name="MSBuildWarning_MultiTarget" xml:space="preserve">
     <value>Packages containing MSBuild targets and props files cannot be fully installed in projects targeting multiple frameworks. The MSBuild targets and props files have been ignored.</value>
   </data>
+  <data name="Log_ResolverConflict" xml:space="preserve">
+    <value>Unable to satisfy conflicting requests for '{0}': {1}</value>
+  </data>
+  <data name="ResolverRequest_ToStringFormat" xml:space="preserve">
+    <value>{0} (via {1})</value>
+  </data>
 </root>

--- a/src/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using NuGet.Logging;
 
 namespace NuGet.DependencyResolver
 {
@@ -39,7 +40,15 @@ namespace NuGet.DependencyResolver
                             return false;
                         }
 
-                        tracker.Track(node.Item);
+                        // HACK(anurse): Reference nodes win all battles.
+                        if (node.Item.Key.Type == "Reference")
+                        {
+                            tracker.Lock(node.Item);
+                        }
+                        else
+                        {
+                            tracker.Track(node.Item);
+                        }
                         return true;
                     });
 

--- a/src/NuGet.DependencyResolver.Core/GraphModel/Tracker.cs
+++ b/src/NuGet.DependencyResolver.Core/GraphModel/Tracker.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -13,7 +14,7 @@ namespace NuGet.DependencyResolver
         public void Track(GraphItem<TItem> item)
         {
             var entry = GetEntry(item);
-            if (!entry.List.Contains(item))
+            if (!entry.List.Contains(item) && !entry.Locked)
             {
                 entry.List.Add(item);
             }
@@ -53,6 +54,14 @@ namespace NuGet.DependencyResolver
             return itemList;
         }
 
+        internal void Lock(GraphItem<TItem> item)
+        {
+            var entry = GetEntry(item);
+            entry.List.Clear();
+            entry.List.Add(item);
+            entry.Locked = true;
+        }
+
         private class Entry
         {
             public Entry()
@@ -63,6 +72,7 @@ namespace NuGet.DependencyResolver
             public HashSet<GraphItem<TItem>> List { get; set; }
 
             public bool Ambiguous { get; set; }
+            public bool Locked { get; set; }
         }
     }
 }

--- a/src/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -134,6 +134,11 @@ namespace NuGet.DependencyResolver
 
             if (match == null)
             {
+                // HACK(anurse): Reference requests are not resolved and just left as-is
+                if (libraryRange.TypeConstraint.Equals(LibraryTypes.Reference))
+                {
+                    return CreateReferenceMatch(libraryRange);
+                }
                 return CreateUnresolvedMatch(libraryRange);
             }
 
@@ -146,6 +151,29 @@ namespace NuGet.DependencyResolver
                     Match = match,
                     Dependencies = dependencies
                 },
+            };
+        }
+
+        private GraphItem<RemoteResolveResult> CreateReferenceMatch(LibraryRange libraryRange)
+        {
+            var identity = new LibraryIdentity()
+            {
+                Name = libraryRange.Name,
+                Type = LibraryTypes.Reference,
+                Version = libraryRange.VersionRange?.MinVersion
+            };
+            return new GraphItem<RemoteResolveResult>(identity)
+            {
+                Data = new RemoteResolveResult()
+                {
+                    Match = new RemoteMatch()
+                    {
+                        Library = identity,
+                        Path = null,
+                        Provider = null
+                    },
+                    Dependencies = Enumerable.Empty<LibraryDependency>()
+                }
             };
         }
 

--- a/src/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -135,7 +135,7 @@ namespace NuGet.DependencyResolver
             if (match == null)
             {
                 // HACK(anurse): Reference requests are not resolved and just left as-is
-                if (libraryRange.TypeConstraint.Equals(LibraryTypes.Reference))
+                if (string.Equals(libraryRange.TypeConstraint, LibraryTypes.Reference))
                 {
                     return CreateReferenceMatch(libraryRange);
                 }

--- a/src/NuGet.Frameworks/FrameworkRuntimePair.cs
+++ b/src/NuGet.Frameworks/FrameworkRuntimePair.cs
@@ -1,0 +1,62 @@
+﻿using System;
+
+namespace NuGet.Frameworks
+{
+    public class FrameworkRuntimePair : IEquatable<FrameworkRuntimePair>, IComparable<FrameworkRuntimePair>
+    {
+        public NuGetFramework Framework { get; }
+        public string RuntimeIdentifier { get; }
+        public string Name { get; }
+
+        public FrameworkRuntimePair(NuGetFramework framework, string runtimeIdentifier)
+        {
+            Framework = framework;
+            RuntimeIdentifier = runtimeIdentifier ?? string.Empty;
+            Name = GetName(framework, runtimeIdentifier);
+        }
+
+        public bool Equals(FrameworkRuntimePair other)
+        {
+            return other != null &&
+                Equals(Framework, other.Framework) &&
+                string.Equals(RuntimeIdentifier, other.RuntimeIdentifier, StringComparison.Ordinal);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as FrameworkRuntimePair);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCodeCombiner.GetHashCode(Framework, RuntimeIdentifier);
+        }
+
+        public override string ToString()
+        {
+            return $"{Framework.GetShortFolderName()}~{RuntimeIdentifier}";
+        }
+
+        public int CompareTo(FrameworkRuntimePair other)
+        {
+            var fxCompare = Framework.GetShortFolderName().CompareTo(other.Framework.GetShortFolderName());
+            if(fxCompare != 0)
+            {
+                return fxCompare;
+            }
+            return string.Compare(RuntimeIdentifier, other.RuntimeIdentifier, StringComparison.Ordinal);
+        }
+
+        public static string GetName(NuGetFramework framework, string runtimeIdentifier)
+        {
+            if (string.IsNullOrEmpty(runtimeIdentifier))
+            {
+                return framework.ToString();
+            }
+            else
+            {
+                return $"{framework} ({runtimeIdentifier})";
+            }
+        }
+    }
+}

--- a/src/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.ProjectModel/PackageSpec.cs
@@ -60,7 +60,7 @@ namespace NuGet.ProjectModel
 
         public IDictionary<string, IEnumerable<string>> Scripts { get; private set; }
 
-        public List<TargetFrameworkInformation> TargetFrameworks { get; private set; }
+        public IList<TargetFrameworkInformation> TargetFrameworks { get; private set; }
 
         public RuntimeGraph RuntimeGraph { get; set; }
 

--- a/src/NuGet.RuntimeModel/CompatibilityProfile.cs
+++ b/src/NuGet.RuntimeModel/CompatibilityProfile.cs
@@ -1,0 +1,46 @@
+﻿using NuGet.Frameworks;
+using System.Collections.Generic;
+using System;
+using System.Linq;
+using NuGet.Common;
+
+namespace NuGet.RuntimeModel
+{
+    public class CompatibilityProfile : IEquatable<CompatibilityProfile>
+    {
+        public string Name { get; }
+        public IList<FrameworkRuntimePair> RestoreContexts { get; }
+
+        public CompatibilityProfile(string name)
+            : this(name, Enumerable.Empty<FrameworkRuntimePair>())
+        { }
+
+        public CompatibilityProfile(string name, IEnumerable<FrameworkRuntimePair> restoreContexts)
+        {
+            Name = name;
+            RestoreContexts = restoreContexts.ToList();
+        }
+
+        public override string ToString()
+        {
+            return $"{Name}: {string.Join(",", RestoreContexts)}";
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCodeCombiner.GetHashCode(Name, RestoreContexts);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as CompatibilityProfile);
+        }
+
+        public bool Equals(CompatibilityProfile other)
+        {
+            return other != null &&
+                string.Equals(Name, other.Name, StringComparison.Ordinal) &&
+                RestoreContexts.OrderBy(r => r).SequenceEqual(other.RestoreContexts.OrderBy(r => r));
+        }
+    }
+}

--- a/src/NuGet.RuntimeModel/RuntimeDependencySet.cs
+++ b/src/NuGet.RuntimeModel/RuntimeDependencySet.cs
@@ -27,9 +27,18 @@ namespace NuGet.RuntimeModel
 
         public bool Equals(RuntimeDependencySet other)
         {
-            return other != null &&
-                   string.Equals(other.Id, Id, StringComparison.Ordinal) &&
-                   Dependencies.OrderBy(p => p.Key).SequenceEqual(other.Dependencies.OrderBy(p => p.Key));
+            // Breaking this up to ease debugging. The optimizer should be able to handle this, so don't refactor unless you have data :).
+            if (other == null)
+            {
+                return false;
+            }
+
+            var dependenciesEqual = Dependencies
+                .OrderBy(p => p.Key)
+                .SequenceEqual(other.Dependencies.OrderBy(p => p.Key));
+
+            return string.Equals(other.Id, Id, StringComparison.Ordinal) &&
+                   dependenciesEqual;
         }
 
         public override bool Equals(object obj)
@@ -48,6 +57,11 @@ namespace NuGet.RuntimeModel
         public RuntimeDependencySet Clone()
         {
             return new RuntimeDependencySet(Id, Dependencies.Values.Select(d => d.Clone()));
+        }
+
+        public override string ToString()
+        {
+            return $"{Id} -> {string.Join(",", Dependencies.Select(d => d.Value.Id + " " + d.Value.VersionRange.ToString()))}";
         }
     }
 }

--- a/src/NuGet.RuntimeModel/RuntimePackageDependency.cs
+++ b/src/NuGet.RuntimeModel/RuntimePackageDependency.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using NuGet.Common;
 using NuGet.Versioning;
 
 namespace NuGet.RuntimeModel
 {
-    public class RuntimePackageDependency
+    public class RuntimePackageDependency : IEquatable<RuntimePackageDependency>
     {
         public string Id { get; }
         public VersionRange VersionRange { get; }
@@ -24,6 +26,23 @@ namespace NuGet.RuntimeModel
         public override string ToString()
         {
             return $"{Id} {VersionRange}";
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as RuntimePackageDependency);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCodeCombiner.GetHashCode(Id, VersionRange);
+        }
+
+        public bool Equals(RuntimePackageDependency other)
+        {
+            return other != null &&
+                string.Equals(Id, other.Id, StringComparison.OrdinalIgnoreCase) &&
+                VersionRange.Equals(other.VersionRange);
         }
     }
 }

--- a/src/NuGet.RuntimeModel/project.json
+++ b/src/NuGet.RuntimeModel/project.json
@@ -7,7 +7,8 @@
     "dependencies": {
         "Newtonsoft.Json": "6.0.6",
         "NuGet.Common": { "type": "build",  "version": "3.1.0-*" },
-        "NuGet.Versioning": "3.1.0-*"
+        "NuGet.Versioning": "3.1.0-*",
+        "NuGet.Frameworks": "3.1.0-*"
     },
     "frameworks": {
         "net45": {

--- a/test/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -381,7 +381,7 @@ namespace NuGet.Commands.Test
                 !string.IsNullOrEmpty(c.Graph.RuntimeIdentifier)).Issues.Where(c => c.Type == CompatibilityIssueType.ReferenceAssemblyNotImplemented).ToArray();
 
             // Assert
-            Assert.Equal(3, brokenPackages.Length);
+            Assert.True(brokenPackages.Length >= 3);
             Assert.True(brokenPackages.Any(c => c.Package.Id.Equals("System.Globalization") && c.AssemblyName.Equals("System.Globalization")));
             Assert.True(brokenPackages.Any(c => c.Package.Id.Equals("System.IO") && c.AssemblyName.Equals("System.IO")));
             Assert.True(brokenPackages.Any(c => c.Package.Id.Equals("System.Reflection") && c.AssemblyName.Equals("System.Reflection")));

--- a/test/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -97,7 +97,7 @@ namespace NuGet.Commands.Test
             var jsonNetPackage = installed.SingleOrDefault(package => package.Name == "Newtonsoft.Json");
 
             // Assert
-            Assert.Equal(9, logger.Errors); // There will be compatibility errors, but we don't care
+            Assert.Equal(6, logger.Errors); // There will be compatibility errors, but we don't care
             Assert.Equal(3, installed.Count);
             Assert.Equal(0, unresolved.Count);
             Assert.Equal("5.0.4", jsonNetPackage.Version.ToNormalizedString());
@@ -289,7 +289,7 @@ namespace NuGet.Commands.Test
             Assert.False(result.CompatibilityCheckResults.Any(c => c.Success));
             Assert.Contains(expectedIssue.Format(), logger.Messages);
 
-            Assert.Equal(9, logger.Errors);
+            Assert.Equal(6, logger.Errors);
             Assert.Equal(2, installed.Count);
             Assert.Equal(0, unresolved.Count);
             Assert.Equal(0, runtimeAssemblies.Count);
@@ -326,9 +326,8 @@ namespace NuGet.Commands.Test
 
             // Assert
             Assert.False(result.Success);
-            Assert.Null(result.LockFile);
 
-            Assert.Equal(1, logger.Errors);
+            Assert.Equal(2, logger.Errors);
             Assert.Equal(1, unresolved.Count);
             Assert.Equal(0, installed.Count);
         }
@@ -382,11 +381,9 @@ namespace NuGet.Commands.Test
                 !string.IsNullOrEmpty(c.Graph.RuntimeIdentifier)).Issues.Where(c => c.Type == CompatibilityIssueType.ReferenceAssemblyNotImplemented).ToArray();
 
             // Assert
-            Assert.Equal(5, brokenPackages.Length);
+            Assert.Equal(3, brokenPackages.Length);
             Assert.True(brokenPackages.Any(c => c.Package.Id.Equals("System.Globalization") && c.AssemblyName.Equals("System.Globalization")));
             Assert.True(brokenPackages.Any(c => c.Package.Id.Equals("System.IO") && c.AssemblyName.Equals("System.IO")));
-            Assert.True(brokenPackages.Any(c => c.Package.Id.Equals("System.Text.Encoding") && c.AssemblyName.Equals("System.Text.Encoding")));
-            Assert.True(brokenPackages.Any(c => c.Package.Id.Equals("System.Threading.Tasks") && c.AssemblyName.Equals("System.Threading.Tasks")));
             Assert.True(brokenPackages.Any(c => c.Package.Id.Equals("System.Reflection") && c.AssemblyName.Equals("System.Reflection")));
         }
 

--- a/test/NuGet.Commands.Test/TestLogger.cs
+++ b/test/NuGet.Commands.Test/TestLogger.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace NuGet.Commands.Test
 {
@@ -16,28 +18,39 @@ namespace NuGet.Commands.Test
         public void LogDebug(string data)
         {
             Messages.Enqueue(data);
+            DumpMessage("DEBUG", data);
         }
 
         public void LogError(string data)
         {
             Errors++;
             Messages.Enqueue(data);
+            DumpMessage("ERROR", data);
         }
 
         public void LogInformation(string data)
         {
             Messages.Enqueue(data);
+            DumpMessage("INFO ", data);
         }
 
         public void LogVerbose(string data)
         {
             Messages.Enqueue(data);
+            DumpMessage("TRACE", data);
         }
 
         public void LogWarning(string data)
         {
             Warnings++;
             Messages.Enqueue(data);
+            DumpMessage("WARN ", data);
+        }
+        
+        private void DumpMessage(string level, string data)
+        {
+            // NOTE(anurse): Uncomment this to help when debugging tests
+            //Console.WriteLine($"{level}: {data}");
         }
     }
 }

--- a/test/NuGet.RuntimeModel.Test/JsonRuntimeFormatTests.cs
+++ b/test/NuGet.RuntimeModel.Test/JsonRuntimeFormatTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using NuGet.Frameworks;
 using NuGet.Versioning;
 using Xunit;
 
@@ -15,6 +16,67 @@ namespace NuGet.RuntimeModel.Test
         public void CanParseEmptyRuntimeJsons(string content)
         {
             Assert.Equal(RuntimeGraph.Empty, ParseRuntimeJsonString(content));
+        }
+
+        [Fact]
+        public void CanParseSupportsSection()
+        {
+            const string content = @"
+{
+    ""supports"": {
+        ""windows-frob"": {
+            ""netcore50"": [ ""winfrob-x86"", ""winfrob-x64"" ]
+        }
+    }
+}";
+            Assert.Equal(
+                new RuntimeGraph(new []
+                    {
+                        new CompatibilityProfile("windows-frob", new []
+                            {
+                                new FrameworkRuntimePair(FrameworkConstants.CommonFrameworks.NetCore50, "winfrob-x86"),
+                                new FrameworkRuntimePair(FrameworkConstants.CommonFrameworks.NetCore50, "winfrob-x64")
+                            })
+                    }),
+                ParseRuntimeJsonString(content));
+        }
+
+        [Fact]
+        public void CanParseSupportsAsFoundInProjectFiles()
+        {
+            const string content = @"
+{
+    ""supports"": {
+        ""windows-frob"": {}
+    }
+}";
+            Assert.Equal(
+                new RuntimeGraph(new []
+                    {
+                        new CompatibilityProfile("windows-frob")
+                    }),
+                ParseRuntimeJsonString(content));
+        }
+
+        [Fact]
+        public void CanParseCompatProfilesWithoutRuntimeIDs()
+        {
+            const string content = @"
+{
+    ""supports"": {
+        ""windows-phone-8"": {
+            ""wp8"": """"
+        }
+    }
+}";
+            Assert.Equal(
+                new RuntimeGraph(new []
+                    {
+                        new CompatibilityProfile("windows-phone-8", new [] {
+                            new FrameworkRuntimePair(FrameworkConstants.CommonFrameworks.WP8, null)
+                        })
+                    }),
+                ParseRuntimeJsonString(content));
         }
 
         [Fact]


### PR DESCRIPTION
This teaches nuget3 how to read the PCL compatibility profile names from project.json and runtime.json files. A Compatibility Profile is a named set of `(txm, rid)` tuples defined in the `supports` section of `project.json` or a `runtime.json`.

For example, the following project.json syntax can be used to request compatibility checks be performed (taken from `misc\RestoreTests\PclExample`).

``` json
{
    "supports": {
        "woozlewuzzle.app": {},
        "silverlight.app": {
            "sl40": ""
        },
        "net46.app": {},
        "dnxcore50.app": {}
    }
}
```

Given a `runtime.json` in the graph that defines `net46.app` and `dnxcore50.app` as such:

``` json
{
    "supports": {
        "net46.app": {
            "net46": [
                "win-x86",
                "win-x64"
            ]
        },
        "dnxcore50.app": {
            "dnxcore50": [
                "win7-x86",
                "win7-x64"
            ]
        }
    }
}
```

The restore will automatically add the following compatibility checks (`TxM~RID`):
- `sl40`
- `net46~win-x86`
- `net46~win-x64`
- `dnxcore50~win7-x86`
- `dnxcore50~win7-x64`

Note that a warning will be displayed because `woozlewuzzle.app` is not defined in the `project.json` or any `runtime.json`:

```
warn : Unknown Compatibility Profile: woozlewuzzle.app
```

Exact syntax of the supports node is as follows:

```
{
    "supports": {
        "<profile-name>": {
            "<txm1>": ["<rid1>", "<rid2>", ...],
            "<txm2>": "<rid1>",
            "<txm3>": ""
        }
    }
}
```

Where:
- `profile-name` is an arbitrary string giving a name to the profile
- `txmN` are TxMs
- `ridN` are Runtime Identifiers

The `"<txm>": "<rid>"` syntax is a shorthand for `"<txm>":["<rid>"]` (array of size one) and the `"<txm>":""` syntax adds a runtime-agnostic TxM to the set

A few minor issues brought up by this:
1. We previously kept a separate runtime graph for each item in `frameworks`, but now we need to merge all the graphs in order to produce a single graph we can use to find the names of "Compatibility Profiles". This is possible, but it means we have to change the way we treat `#imports` slightly. Before, we did not allow two different files to define `#imports` for a runtime and produced an error. Now, we still do not allow it but rather than producing an error, we simply discard one of them (arbitrarily). Perhaps we could check that they are identical and error if they are not.
2. It is up to the project author to ensure that the `runtime.json` files defining their compatibility profiles are available in **at least one** of their target framework graphs. Without the `runtime.json` graph, we are unable to interpret compatibility profile names

<del>Automated tests are not easy to implement at the moment since our existing tests work with live feeds and there is no public feed with these packages (yet).</del> Looks like there is a MyGet feed, I'll look at building tests on that.

Manual testing can be performed using the `misc\RestoreTests\PclExample` project and a command line like the following (from the repo root):

```
.\nuget3 restore .\misc\RestoreTests\PclExample\project.json --source https://www.myget.org/F/dotnet-core/api/v2
```

/cc @emgarten @lodejard @davidfowl @yishaigalatzer @ericstj @rchande @jasonmalinowski
