### PR TITLE
handle unresolved packages and report them on the command line

### DIFF
--- a/misc/RestoreTests/Unresolved/project.json
+++ b/misc/RestoreTests/Unresolved/project.json
@@ -1,0 +1,8 @@
+{
+    "dependencies": {
+        "NotARealDependency": "1.0.0"
+    },
+    "frameworks": {
+        "dotnet": {}
+    }
+}

--- a/src/NuGet.Commands/Properties/Strings.Designer.cs
+++ b/src/NuGet.Commands/Properties/Strings.Designer.cs
@@ -43,7 +43,7 @@ namespace NuGet.Commands
         }
 
         /// <summary>
-        /// Failed to resolve conflicts.
+        /// Failed to resolve conflicts for {0}.
         /// </summary>
         internal static string Log_FailedToResolveConflicts
         {
@@ -51,11 +51,11 @@ namespace NuGet.Commands
         }
 
         /// <summary>
-        /// Failed to resolve conflicts.
+        /// Failed to resolve conflicts for {0}.
         /// </summary>
-        internal static string FormatLog_FailedToResolveConflicts()
+        internal static string FormatLog_FailedToResolveConflicts(object p0)
         {
-            return GetString("Log_FailedToResolveConflicts");
+            return string.Format(CultureInfo.CurrentCulture, GetString("Log_FailedToResolveConflicts"), p0);
         }
 
         /// <summary>
@@ -264,6 +264,22 @@ namespace NuGet.Commands
         internal static string FormatLog_SkippingRuntimeWalk()
         {
             return GetString("Log_SkippingRuntimeWalk");
+        }
+
+        /// <summary>
+        /// Unable to resolve {0} {1} for {2}.
+        /// </summary>
+        internal static string Log_UnresolvedDependency
+        {
+            get { return GetString("Log_UnresolvedDependency"); }
+        }
+
+        /// <summary>
+        /// Unable to resolve {0} {1} for {2}.
+        /// </summary>
+        internal static string FormatLog_UnresolvedDependency(object p0, object p1, object p2)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Log_UnresolvedDependency"), p0, p1, p2);
         }
 
         /// <summary>

--- a/src/NuGet.Commands/RestoreGraph.cs
+++ b/src/NuGet.Commands/RestoreGraph.cs
@@ -104,8 +104,7 @@ namespace NuGet.Commands
                         return;
                     }
 
-                    if (node.Item == null
-                        || node.Item.Data.Match == null)
+                    if (string.Equals(node?.Item?.Key?.Type, LibraryTypes.Unresolved))
                     {
                         if (node.Key.TypeConstraint != LibraryTypes.Reference
                             &&

--- a/src/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Commands/Strings.resx
@@ -124,7 +124,7 @@
     <value>Checking compatibility for {0} {1} with {2}.</value>
   </data>
   <data name="Log_FailedToResolveConflicts" xml:space="preserve">
-    <value>Failed to resolve conflicts.</value>
+    <value>Failed to resolve conflicts for {0}.</value>
   </data>
   <data name="Log_GeneratingMsBuildFile" xml:space="preserve">
     <value>Generating MSBuild file {0}.</value>
@@ -164,6 +164,9 @@
   </data>
   <data name="Log_SkippingRuntimeWalk" xml:space="preserve">
     <value>Skipping runtime dependency walk, no runtimes defined in project.json.</value>
+  </data>
+  <data name="Log_UnresolvedDependency" xml:space="preserve">
+    <value>Unable to resolve {0} {1} for {2}.</value>
   </data>
   <data name="Log_UsingSource" xml:space="preserve">
     <value>Using source {0}.</value>

--- a/src/NuGet.LibraryModel/LibraryTypes.cs
+++ b/src/NuGet.LibraryModel/LibraryTypes.cs
@@ -35,5 +35,10 @@ namespace NuGet.LibraryModel
         /// Indicates that the library comes from a Windows Metadata Assembly (.winmd file)
         /// </summary>
         public const string WinMD = "WinMD";
+
+        /// <summary>
+        /// Indicates that the library could not be resolved
+        /// </summary>
+        public const string Unresolved = "Unresolved";
     }
 }


### PR DESCRIPTION
Fixes NuGet/Home#591

We need to actually handle unresolved dependencies and mark them as such. This change does that and also adds a test project for the command line as well as an automated functional test.

/cc @davidfowl @pranavkm @emgarten @yishaigalatzer 
