### PR TITLE
fix NuGet/Home#751 by reading references out of the nuspec directly

### DIFF
--- a/src/NuGet.Commands/LockFileUtils.cs
+++ b/src/NuGet.Commands/LockFileUtils.cs
@@ -52,7 +52,8 @@ namespace NuGet.Commands
                     }
                 }
 
-                var referenceSet = packageReader.GetReferenceItems().GetNearest(framework);
+                var nuspec = new NuspecReader(packageReader.GetNuspec());
+                var referenceSet = nuspec.GetReferenceGroups().GetNearest(framework);
                 if (referenceSet != null)
                 {
                     referenceFilter = new HashSet<string>(referenceSet.Items, StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
The issue here was that `GetReferenceItems` _merges_ the `<references>` node with the actual contents of `lib/`, which defeats the usage of the NuGet ContentModel code, since it ends up filtering everything out (because GetReferenceItems returns an empty set when a framework has a `lib/tfm/_._` file) instead of generating a single `runtime` resource: `lib/tfm/_._`

Fixes NuGet/Home#751

/cc @davidfowl @pranavkm @emgarten @yishaigalatzer 
