### PR TITLE
fix unit test failures

### DIFF
--- a/src/NuGet.Client/ManagedCodeConventions.cs
+++ b/src/NuGet.Client/ManagedCodeConventions.cs
@@ -28,7 +28,9 @@ namespace NuGet.Client
         private static readonly ContentPropertyDefinition LocaleProperty = new ContentPropertyDefinition(PropertyNames.Locale,
             parser: Locale_Parser);
 
-        private static readonly ContentPropertyDefinition AnyProperty = new ContentPropertyDefinition(PropertyNames.AnyValue);
+        private static readonly ContentPropertyDefinition AnyProperty = new ContentPropertyDefinition(
+            PropertyNames.AnyValue, 
+            parser: o => o); // Identity parser, all strings are valid for any
         private static readonly ContentPropertyDefinition AssemblyProperty = new ContentPropertyDefinition(PropertyNames.ManagedAssembly, fileExtensions: new[] { ".dll" });
         private static readonly ContentPropertyDefinition MSBuildProperty = new ContentPropertyDefinition(PropertyNames.MSBuild, fileExtensions: new[] { ".targets", ".props" });
 
@@ -51,6 +53,7 @@ namespace NuGet.Client
 
             props[PropertyNames.RuntimeIdentifier] = new ContentPropertyDefinition(
                 PropertyNames.RuntimeIdentifier,
+                parser: o => o, // Identity parser, all strings are valid runtime ids :)
                 compatibilityTest: RuntimeIdentifier_CompatibilityTest);
 
             Properties = new ReadOnlyDictionary<string, ContentPropertyDefinition>(props);

--- a/src/NuGet.ContentModel/ContentPropertyDefinition.cs
+++ b/src/NuGet.ContentModel/ContentPropertyDefinition.cs
@@ -94,7 +94,7 @@ namespace NuGet.ContentModel
             }
             Table = new ReadOnlyDictionary<string, object>(table); // Wraps the dictionary in a read-only container. Does NOT copy!
 
-            Parser = parser ?? (o => o);
+            Parser = parser;
             CompatibilityTest = compatibilityTest ?? Equals;
             CompareTest = compareTest;
             FileExtensions = (fileExtensions ?? Enumerable.Empty<string>()).ToList();


### PR DESCRIPTION
The `assembly` property wasn't working correctly with file extensions because it had a parser. This fixes it by making the default parser `null` and only establishing a parser for the things that need it.

Pushing this in to fix the build but here's a PR to see the changes

/cc @emgarten 
