### PR TITLE
change reference filter to use file name instead of full path

### DIFF
--- a/src/NuGet.Commands/LockFileUtils.cs
+++ b/src/NuGet.Commands/LockFileUtils.cs
@@ -122,8 +122,8 @@ namespace NuGet.Commands
             {
                 // Remove anything that starts with "lib/" and is NOT specified in the reference filter.
                 // runtimes/* is unaffected (it doesn't start with lib/)
-                lockFileLib.RuntimeAssemblies = lockFileLib.RuntimeAssemblies.Where(p => !p.Path.StartsWith("lib/") || referenceFilter.Contains(p.Path)).ToList();
-                lockFileLib.CompileTimeAssemblies = lockFileLib.CompileTimeAssemblies.Where(p => !p.Path.StartsWith("lib/") || referenceFilter.Contains(p.Path)).ToList();
+                lockFileLib.RuntimeAssemblies = lockFileLib.RuntimeAssemblies.Where(p => !p.Path.StartsWith("lib/") || referenceFilter.Contains(Path.GetFileName(p.Path))).ToList();
+                lockFileLib.CompileTimeAssemblies = lockFileLib.CompileTimeAssemblies.Where(p => !p.Path.StartsWith("lib/") || referenceFilter.Contains(Path.GetFileName(p.Path))).ToList();
             }
 
             return lockFileLib;


### PR DESCRIPTION
further fix for NuGet/Home#751

/cc @davidfowl @emgarten @yishaigalatzer @pranavkm 
