### PR TITLE
Switching to using Semaphore without timeouts in ConcurrencyUtilities.

### DIFF
--- a/src/NuGet.Packaging/PackageExtraction/NuGetPackageUtils.cs
+++ b/src/NuGet.Packaging/PackageExtraction/NuGetPackageUtils.cs
@@ -34,7 +34,7 @@ namespace NuGet.Packaging
 
             // Acquire the lock on a nukpg before we extract it to prevent the race condition when multiple
             // processes are extracting to the same destination simultaneously
-            await ConcurrencyUtilities.ExecuteWithFileLocked(targetNupkg, async () =>
+            await ConcurrencyUtilities.ExecuteWithFileLocked<int>(targetNupkg, TimeSpan.FromMinutes(1), async _ =>
                 {
                     // If this is the first process trying to install the target nupkg, go ahead
                     // After this process successfully installs the package, all other processes

--- a/src/NuGet.Protocol.Core.v3/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
+++ b/src/NuGet.Protocol.Core.v3/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
@@ -250,7 +250,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
 
             // Acquire the lock on a file before we open it to prevent this process
             // from opening a file deleted by the logic in HttpSource.GetAsync() in another process
-            return await ConcurrencyUtilities.ExecuteWithFileLocked(result.TempFileName, () =>
+            return await ConcurrencyUtilities.ExecuteWithFileLocked(result.TempFileName, TimeSpan.FromMinutes(1), _ =>
                 {
                     return Task.FromResult(
                         new FileStream(result.TempFileName, FileMode.Open, FileAccess.Read,

--- a/src/NuGet.Protocol.Core.v3/RemoteRepositories/HttpSource.cs
+++ b/src/NuGet.Protocol.Core.v3/RemoteRepositories/HttpSource.cs
@@ -163,7 +163,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
             // The update of a cached file is divided into two steps:
             // 1) Delete the old file. 2) Create a new file with the same name.
             // To prevent race condition among multiple processes, here we use a lock to make the update atomic.
-            await ConcurrencyUtilities.ExecuteWithFileLocked(result.CacheFileName, async () =>
+            await ConcurrencyUtilities.ExecuteWithFileLocked(result.CacheFileName, TimeSpan.FromMinutes(1), async _ =>
                 {
                     using (var stream = new FileStream(
                         newFile,
@@ -238,7 +238,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
 
             // Acquire the lock on a file before we open it to prevent this process
             // from opening a file deleted by the logic in HttpSource.GetAsync() in another process
-            return await ConcurrencyUtilities.ExecuteWithFileLocked(cacheFile, () =>
+            return await ConcurrencyUtilities.ExecuteWithFileLocked(cacheFile, TimeSpan.FromMinutes(1), _ =>
                 {
                     if (File.Exists(cacheFile))
                     {

--- a/src/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
+++ b/src/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
@@ -269,7 +269,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
 
             // Acquire the lock on a file before we open it to prevent this process
             // from opening a file deleted by the logic in HttpSource.GetAsync() in another process
-            return await ConcurrencyUtilities.ExecuteWithFileLocked(result.TempFileName, () =>
+            return await ConcurrencyUtilities.ExecuteWithFileLocked(result.TempFileName, TimeSpan.FromMinutes(1), _ =>
                 {
                     return Task.FromResult(
                         new FileStream(result.TempFileName, FileMode.Open, FileAccess.Read,

--- a/src/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
+++ b/src/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
@@ -166,7 +166,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
 
             // Acquire the lock on a file before we open it to prevent this process
             // from opening a file deleted by the logic in HttpSource.GetAsync() in another process
-            return await ConcurrencyUtilities.ExecuteWithFileLocked(result.TempFileName, () =>
+            return await ConcurrencyUtilities.ExecuteWithFileLocked(result.TempFileName, TimeSpan.FromMinutes(1), _ =>
                 {
                     return Task.FromResult(
                         new FileStream(result.TempFileName, FileMode.Open, FileAccess.Read,


### PR DESCRIPTION
Ported from https://github.com/aspnet/dnx/commit/955fc0904614f3ca70bffaa65d7f134372497857

cc @deepakaravindr @emgarten @yishaigalatzer 
