### PR TITLE
fix NuGet/Home#752 by allowing asm.ni.dll to match a ref assembly for asm

### DIFF
--- a/misc/RestoreTests/NativeImageMatch/project.json
+++ b/misc/RestoreTests/NativeImageMatch/project.json
@@ -1,0 +1,14 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.UniversalWindowsPlatform": "1.0.0-beta-*"
+  },
+  "frameworks": {
+    "netcore50": {}
+  },
+  "runtimes": {
+    "win10-x86": {},
+    "win10-x86-aot": {},
+    "win10-x64": {},
+    "win10-x64-aot": {}
+  }
+}

--- a/src/NuGet.Commands/CompatilibityChecker.cs
+++ b/src/NuGet.Commands/CompatilibityChecker.cs
@@ -94,6 +94,12 @@ namespace NuGet.Commands
                     {
                         string name = Path.GetFileNameWithoutExtension(runtime.Path);
 
+                        // Fix for NuGet/Home#752 - Consider ".ni.dll" (native image/ngen) files matches for ref/ assemblies
+                        if (name.EndsWith(".ni"))
+                        {
+                            name = name.Substring(0, name.Length - 3);
+                        }
+
                         // If there was a compile-time-only assembly under this name...
                         if (compileAssemblies.ContainsKey(name))
                         {


### PR DESCRIPTION
Fixes NuGet/Home#752

CLR packages will have some cases where there is a `ref/Foo.dll` and no `lib/Foo.dll`, instead there will be a `lib/Foo.ni.dll` (often inside a runtimes directory). This should be considered a match when pairing up ref and lib assemblies. We already put `.ni.dll` files into the lock file so this is a pretty minor and low-impact fix.

/cc @ericstj @emgarten @yishaigalatzer @davidfowl 
