### PR TITLE
fix NuGet/Home#784 by copying from remote provider directly to destination file

### DIFF
--- a/src/NuGet.Commands/RestoreCommand.cs
+++ b/src/NuGet.Commands/RestoreCommand.cs
@@ -606,12 +606,9 @@ namespace NuGet.Commands
         {
             using (var memoryStream = new MemoryStream())
             {
-                await installItem.Provider.CopyToAsync(installItem.Library, memoryStream, CancellationToken.None);
-
-                memoryStream.Seek(0, SeekOrigin.Begin);
-
                 var packageIdentity = new PackageIdentity(installItem.Library.Name, installItem.Library.Version);
-                await NuGetPackageUtils.InstallFromStreamAsync(memoryStream,
+                await NuGetPackageUtils.InstallFromSourceAsync(
+                    stream => installItem.Provider.CopyToAsync(installItem.Library, stream, CancellationToken.None),
                     packageIdentity,
                     packagesDirectory,
                     _log,

--- a/src/NuGet.Packaging/PackageExtraction/NuGetPackageUtils.cs
+++ b/src/NuGet.Packaging/PackageExtraction/NuGetPackageUtils.cs
@@ -19,8 +19,8 @@ namespace NuGet.Packaging
     {
         private const string ManifestExtension = ".nuspec";
 
-        public static async Task InstallFromStreamAsync(
-            Stream stream,
+        public static async Task InstallFromSourceAsync(
+            Func<Stream, Task> copyToAsync,
             PackageIdentity packageIdentity,
             string packagesDirectory,
             ILogger log,
@@ -55,7 +55,7 @@ namespace NuGet.Packaging
                             bufferSize: 4096,
                             useAsync: true))
                         {
-                            await stream.CopyToAsync(nupkgStream);
+                            await copyToAsync(nupkgStream);
                             nupkgStream.Seek(0, SeekOrigin.Begin);
 
                             ExtractPackage(targetPath, nupkgStream);

--- a/src/NuGet.Protocol.Core.v3/Utility/GlobalPackagesFolderUtility.cs
+++ b/src/NuGet.Protocol.Core.v3/Utility/GlobalPackagesFolderUtility.cs
@@ -84,7 +84,8 @@ namespace NuGet.Protocol.Core.v3
 
             // The following call adds it to the global packages folder. Addition is performed using ConcurrentUtils, such that,
             // multiple processes may add at the same time
-            await NuGetPackageUtils.InstallFromStreamAsync(packageStream,
+            await NuGetPackageUtils.InstallFromSourceAsync(
+                stream => packageStream.CopyToAsync(stream),
                 packageIdentity,
                 globalPackagesFolder,
                 NullLogger.Instance,


### PR DESCRIPTION
Fixes NuGet/Home#784

/cc @emgarten @yishaigalatzer @davidfowl 
