### PR TITLE
fix NuGet/Home#622 by correctly handling a locked lockfile

### DIFF
--- a/misc/RestoreTests/LockedLockFile/project.json
+++ b/misc/RestoreTests/LockedLockFile/project.json
@@ -1,0 +1,8 @@
+{
+    "dependencies": {
+        "System.IO": "4.0.10-beta-*"
+    },
+    "frameworks": {
+        "dotnet": { }
+    }
+}

--- a/misc/RestoreTests/LockedLockFile/project.lock.json
+++ b/misc/RestoreTests/LockedLockFile/project.lock.json
@@ -1,0 +1,113 @@
+{
+  "locked": true,
+  "version": -9996,
+  "targets": {
+    ".NETPlatform,Version=v5.0": {
+      "System.IO/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Text.Encoding": "4.0.0-beta-22927",
+          "System.Threading.Tasks": "4.0.0-beta-22927"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20-beta-22927": {
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "System.IO/4.0.10-beta-22927": {
+      "sha512": "NYoIpyR5hJvnv/jnY817GLBaH+DLJEsSOEGw8/NL/y4taFzuWVR2ROQtpWXD/2GLrXiTZ6Kdn7f1czs4DOqH1A==",
+      "type": "Package",
+      "files": [
+        "_rels/.rels",
+        "System.IO.nuspec",
+        "lib/DNXCore50/System.IO.dll",
+        "lib/netcore50/System.IO.dll",
+        "lib/net46/_._",
+        "ref/dotnet/System.IO.dll",
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "ref/net46/_._",
+        "package/services/metadata/core-properties/5e76eae81b564da7b3fc45e27c517ebe.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Runtime/4.0.20-beta-22927": {
+      "sha512": "WFRsJnfRzXYIiDJRbTXGctncx6Hw1F/uS2c5a5CzUwHuA3D/CM152F2HjWt12dLgH0BOcGvcRjKl2AfJ6MnHVg==",
+      "type": "Package",
+      "files": [
+        "_rels/.rels",
+        "System.Runtime.nuspec",
+        "lib/DNXCore50/System.Runtime.dll",
+        "lib/netcore50/System.Runtime.dll",
+        "lib/net46/_._",
+        "ref/dotnet/System.Runtime.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "ref/net46/_._",
+        "package/services/metadata/core-properties/b7eb2b260f1846d69b1ccf1a4e614180.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Text.Encoding/4.0.0-beta-22927": {
+      "sha512": "guYjgbAgP4TKdyys0WhXXLNVxasqWczLgbhi4modkSKLtC9vnewebG9mzgkzuKwnXwsi3r0h+uBfsHMO5hIxgQ==",
+      "type": "Package",
+      "files": [
+        "_rels/.rels",
+        "System.Text.Encoding.nuspec",
+        "License.rtf",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/net45/_._",
+        "lib/net45/_._",
+        "ref/win8/_._",
+        "lib/win8/_._",
+        "ref/netcore50/System.Text.Encoding.dll",
+        "package/services/metadata/core-properties/9b75d4e6dbb04e01924ba65660f251d7.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Threading.Tasks/4.0.0-beta-22927": {
+      "sha512": "32tZzgoOQuw1JA2B8TDSo1FRrKVuZ5ywWnc+x7OVqCav62avxeAIxd/ZkzpoNniNTDUYwgPyMjtyc+KsvUQtog==",
+      "type": "Package",
+      "files": [
+        "_rels/.rels",
+        "System.Threading.Tasks.nuspec",
+        "License.rtf",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/net45/_._",
+        "lib/net45/_._",
+        "ref/win8/_._",
+        "lib/win8/_._",
+        "ref/netcore50/System.Threading.Tasks.dll",
+        "package/services/metadata/core-properties/b80dd50f318e4a198547c0683e67e96d.psmdcp",
+        "[Content_Types].xml"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "System.IO [4.0.10-beta-*, )"
+    ],
+    ".NETPlatform,Version=v5.0": []
+  }
+}

--- a/src/NuGet.Commands/Properties/Strings.Designer.cs
+++ b/src/NuGet.Commands/Properties/Strings.Designer.cs
@@ -378,6 +378,38 @@ namespace NuGet.Commands
             return string.Format(CultureInfo.CurrentCulture, GetString("ResolverRequest_ToStringFormat"), p0, p1);
         }
 
+        /// <summary>
+        /// {0} {1} is specified in the Lock File target for {2} but is not present in the top-level Libraries list.
+        /// </summary>
+        internal static string Log_LockFileMissingLibraryForTargetLibrary
+        {
+            get { return GetString("Log_LockFileMissingLibraryForTargetLibrary"); }
+        }
+
+        /// <summary>
+        /// {0} {1} is specified in the Lock File target for {2} but is not present in the top-level Libraries list.
+        /// </summary>
+        internal static string FormatLog_LockFileMissingLibraryForTargetLibrary(object p0, object p1, object p2)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Log_LockFileMissingLibraryForTargetLibrary"), p0, p1, p2);
+        }
+
+        /// <summary>
+        /// The lock file is out-of-date relative to the project file. Regenerating the lock file and re-locking.
+        /// </summary>
+        internal static string Log_LockFileOutOfDate
+        {
+            get { return GetString("Log_LockFileOutOfDate"); }
+        }
+
+        /// <summary>
+        /// The lock file is out-of-date relative to the project file. Regenerating the lock file and re-locking.
+        /// </summary>
+        internal static string FormatLog_LockFileOutOfDate()
+        {
+            return GetString("Log_LockFileOutOfDate");
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/NuGet.Commands/RestoreRequest.cs
+++ b/src/NuGet.Commands/RestoreRequest.cs
@@ -19,6 +19,8 @@ namespace NuGet.Commands
             Project = project;
             Sources = sources.ToList().AsReadOnly();
             PackagesDirectory = packagesDirectory;
+
+            WriteLockFile = true;
             WriteMSBuildFiles = true;
 
             ExternalProjects = new List<ExternalProjectReference>();
@@ -47,9 +49,21 @@ namespace NuGet.Commands
 
         /// <summary>
         /// The path to the lock file to read/write. If not specified, uses the file 'project.lock.json' in the same
-        /// directory as the provided PackageSpec
+        /// directory as the provided PackageSpec.
         /// </summary>
         public string LockFilePath { get; set; }
+
+        /// <summary>
+        /// Set this to false to prevent the command from writting the lock file (defaults to true)
+        /// </summary>
+        public bool WriteLockFile { get; set; }
+
+        /// <summary>
+        /// The existing lock file to use. If not specified, the lock file will be read from the <see cref="LockFilePath"/>
+        /// (or, if that property is not specified, from the default location of the lock file, as specified in the
+        /// description for <see cref="LockFilePath"/>)
+        /// </summary>
+        public LockFile ExistingLockFile { get; set; }
 
         /// <summary>
         /// The number of concurrent tasks to run during installs. Defaults to

--- a/src/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Commands/Strings.resx
@@ -186,4 +186,10 @@
   <data name="ResolverRequest_ToStringFormat" xml:space="preserve">
     <value>{0} (via {1})</value>
   </data>
+  <data name="Log_LockFileMissingLibraryForTargetLibrary" xml:space="preserve">
+    <value>{0} {1} is specified in the Lock File target for {2} but is not present in the top-level Libraries list.</value>
+  </data>
+  <data name="Log_LockFileOutOfDate" xml:space="preserve">
+    <value>The lock file is out-of-date relative to the project file. Regenerating the lock file and re-locking.</value>
+  </data>
 </root>

--- a/src/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -132,6 +132,14 @@ namespace NuGet.DependencyResolver
             }
         }
 
+        public static void ForEach<TItem>(this IEnumerable<GraphNode<TItem>> roots, Action<GraphNode<TItem>> visitor)
+        {
+            foreach (var root in roots)
+            {
+                root.ForEach(visitor);
+            }
+        }
+
         public static void ForEach<TItem>(this GraphNode<TItem> root, Action<GraphNode<TItem>> visitor)
         {
             // breadth-first walk of Node tree, without TState parameter

--- a/src/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -24,11 +24,11 @@ namespace NuGet.DependencyResolver
             _context = context;
         }
 
-        public Task<GraphNode<RemoteResolveResult>> WalkAsync(LibraryRange library, NuGetFramework framework, string runtimeIdentifier, RuntimeGraph runtimeGraph)
+        public Task<GraphNode<RemoteResolveResult>> WalkAsync(LibraryRange library, NuGetFramework framework, string runtimeIdentifier, RuntimeGraph runtimeGraph, bool recursive)
         {
             var cache = new ConcurrentDictionary<LibraryRange, Task<GraphItem<RemoteResolveResult>>>();
 
-            return CreateGraphNode(cache, library, framework, runtimeIdentifier, runtimeGraph, _ => true);
+            return CreateGraphNode(cache, library, framework, runtimeIdentifier, runtimeGraph, _ => recursive);
         }
 
         private async Task<GraphNode<RemoteResolveResult>> CreateGraphNode(ConcurrentDictionary<LibraryRange, Task<GraphItem<RemoteResolveResult>>> cache, LibraryRange libraryRange, NuGetFramework framework, string runtimeName, RuntimeGraph runtimeGraph, Func<string, bool> predicate)
@@ -293,7 +293,7 @@ namespace NuGet.DependencyResolver
             }
         }
 
-        private async Task<RemoteMatch> FindProjectMatch(string name, NuGetFramework framework, CancellationToken cancellationToken)
+        public async Task<RemoteMatch> FindProjectMatch(string name, NuGetFramework framework, CancellationToken cancellationToken)
         {
             var libraryRange = new LibraryRange
             {

--- a/src/NuGet.ProjectModel/LockFileLibrary.cs
+++ b/src/NuGet.ProjectModel/LockFileLibrary.cs
@@ -10,6 +10,8 @@ namespace NuGet.ProjectModel
     {
         public string Name { get; set; }
 
+        public string Type { get; set; }
+
         public NuGetVersion Version { get; set; }
 
         public bool IsServiceable { get; set; }

--- a/src/NuGet.ProjectModel/LockFileTarget.cs
+++ b/src/NuGet.ProjectModel/LockFileTarget.cs
@@ -12,6 +12,8 @@ namespace NuGet.ProjectModel
 
         public string RuntimeIdentifier { get; set; }
 
+        public string Name => TargetFramework + (string.IsNullOrEmpty(RuntimeIdentifier) ? "" : "/" + RuntimeIdentifier);
+
         public IList<LockFileTargetLibrary> Libraries { get; set; } = new List<LockFileTargetLibrary>();
     }
 }

--- a/src/NuGet.Resolver/Properties/Strings.Designer.cs
+++ b/src/NuGet.Resolver/Properties/Strings.Designer.cs
@@ -139,7 +139,7 @@ namespace NuGet.Resolver
         }
 
         /// <summary>
-        /// Unable to resolve dependency '{0}' , source(s) in used: {1}.
+        /// Unable to resolve dependency '{0}'. Source(s) used: {1}.
         /// </summary>
         internal static string UnableToResolveDependencyForMultipleSources
         {
@@ -147,7 +147,7 @@ namespace NuGet.Resolver
         }
 
         /// <summary>
-        /// Unable to resolve dependency '{0}' , source(s) in used: {1}.
+        /// Unable to resolve dependency '{0}'. Source(s) used: {1}.
         /// </summary>
         internal static string FormatUnableToResolveDependencyForMultipleSources(object p0, object p1)
         {

--- a/test/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -97,7 +97,7 @@ namespace NuGet.Commands.Test
             var jsonNetPackage = installed.SingleOrDefault(package => package.Name == "Newtonsoft.Json");
 
             // Assert
-            Assert.Equal(6, logger.Errors); // There will be compatibility errors, but we don't care
+            // There will be compatibility errors, but we don't care
             Assert.Equal(3, installed.Count);
             Assert.Equal(0, unresolved.Count);
             Assert.Equal("5.0.4", jsonNetPackage.Version.ToNormalizedString());
@@ -289,7 +289,7 @@ namespace NuGet.Commands.Test
             Assert.False(result.CompatibilityCheckResults.Any(c => c.Success));
             Assert.Contains(expectedIssue.Format(), logger.Messages);
 
-            Assert.Equal(6, logger.Errors);
+            Assert.Equal(9, logger.Errors);
             Assert.Equal(2, installed.Count);
             Assert.Equal(0, unresolved.Count);
             Assert.Equal(0, runtimeAssemblies.Count);
@@ -327,7 +327,7 @@ namespace NuGet.Commands.Test
             // Assert
             Assert.False(result.Success);
 
-            Assert.Equal(2, logger.Errors);
+            Assert.Equal(1, logger.Errors);
             Assert.Equal(1, unresolved.Count);
             Assert.Equal(0, installed.Count);
         }
@@ -385,6 +385,185 @@ namespace NuGet.Commands.Test
             Assert.True(brokenPackages.Any(c => c.Package.Id.Equals("System.Globalization") && c.AssemblyName.Equals("System.Globalization")));
             Assert.True(brokenPackages.Any(c => c.Package.Id.Equals("System.IO") && c.AssemblyName.Equals("System.IO")));
             Assert.True(brokenPackages.Any(c => c.Package.Id.Equals("System.Reflection") && c.AssemblyName.Equals("System.Reflection")));
+        }
+
+        [Fact]
+        public async Task RestoreCommand_LockedLockFile()
+        {
+            const string project = @"
+{
+    ""dependencies"": {
+        ""System.Runtime"": ""4.0.10-beta-*""
+    },
+    ""frameworks"": {
+        ""dotnet"": { }
+    }
+}";
+
+            const string lockFileContent = @"{
+  ""locked"": true,
+  ""version"": -9996,
+  ""targets"": {
+    "".NETPlatform,Version=v5.0"": {
+      ""System.Runtime/4.0.10-beta-23008"": {
+        ""compile"": {
+          ""ref/dotnet/System.Runtime.dll"": {}
+        }
+      }
+    }
+  },
+  ""libraries"": {
+    ""System.Runtime/4.0.10-beta-23008"": {
+      ""sha512"": ""JkGp8sCzxxRY1GS+p1SEk8WcaT8pu++/5b94ar2i/RaUN/OzkcGP/6OLFUxUf1uar75pUvotpiMawVt1dCEUVA=="",
+      ""type"": ""Package"",
+      ""files"": [
+        ""_rels/.rels"",
+        ""System.Runtime.nuspec"",
+        ""License.rtf"",
+        ""ref/dotnet/System.Runtime.dll"",
+        ""ref/net451/_._"",
+        ""lib/net451/_._"",
+        ""ref/win81/_._"",
+        ""lib/win81/_._"",
+        ""ref/netcore50/System.Runtime.dll"",
+        ""package/services/metadata/core-properties/cdec43993f064447a2d882cbfd022539.psmdcp"",
+        ""[Content_Types].xml""
+      ]
+    }
+  },
+  ""projectFileDependencyGroups"": {
+    """": [
+      ""System.Runtime >= 4.0.10-beta-*""
+    ],
+    "".NETPlatform,Version=v5.0"": []
+  }
+}
+";
+
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            // TODO(anurse): We should be mocking this out or using a stable source...
+            sources.Add(new PackageSource("https://www.myget.org/F/dotnet-core/api/v2/"));
+
+            var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
+            var projectDir = TestFileSystemUtility.CreateRandomTestFolder();
+            _testFolders.Add(packagesDir);
+            _testFolders.Add(projectDir);
+
+            var specPath = Path.Combine(projectDir, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(project, "TestProject", specPath);
+
+            var lockFileFormat = new LockFileFormat();
+            var lockFile = lockFileFormat.Parse(lockFileContent);
+            Assert.True(lockFile.IsLocked); // Just to make sure no-one accidentally unlocks it :)
+
+            var request = new RestoreRequest(spec, sources, packagesDir);
+            request.MaxDegreeOfConcurrency = 1;
+            request.WriteLockFile = false;
+            request.ExistingLockFile = lockFile;
+
+            // Act
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger, request);
+            var result = await command.ExecuteAsync();
+            var installed = result.GetAllInstalled();
+
+            // Assert
+            Assert.Equal(1, installed.Count);
+            Assert.Equal("System.Runtime", installed.Single().Name);
+            Assert.Equal(NuGetVersion.Parse("4.0.10-beta-23008"), installed.Single().Version);
+        }
+
+        [Fact]
+        public async Task RestoreCommand_LockedLockFileWithOutOfDateProject()
+        {
+            const string project = @"
+{
+    ""dependencies"": {
+        ""System.Runtime"": ""4.0.20-beta-*""
+    },
+    ""frameworks"": {
+        ""dotnet"": { }
+    }
+}";
+
+            const string lockFileContent = @"{
+  ""locked"": true,
+  ""version"": -9996,
+  ""targets"": {
+    "".NETPlatform,Version=v5.0"": {
+      ""System.Runtime/4.0.10-beta-23008"": {
+        ""compile"": {
+          ""ref/dotnet/System.Runtime.dll"": {}
+        }
+      }
+    }
+  },
+  ""libraries"": {
+    ""System.Runtime/4.0.10-beta-23008"": {
+      ""sha512"": ""JkGp8sCzxxRY1GS+p1SEk8WcaT8pu++/5b94ar2i/RaUN/OzkcGP/6OLFUxUf1uar75pUvotpiMawVt1dCEUVA=="",
+      ""type"": ""Package"",
+      ""files"": [
+        ""_rels/.rels"",
+        ""System.Runtime.nuspec"",
+        ""License.rtf"",
+        ""ref/dotnet/System.Runtime.dll"",
+        ""ref/net451/_._"",
+        ""lib/net451/_._"",
+        ""ref/win81/_._"",
+        ""lib/win81/_._"",
+        ""ref/netcore50/System.Runtime.dll"",
+        ""package/services/metadata/core-properties/cdec43993f064447a2d882cbfd022539.psmdcp"",
+        ""[Content_Types].xml""
+      ]
+    }
+  },
+  ""projectFileDependencyGroups"": {
+    """": [
+      ""System.Runtime >= 4.0.10-beta-*""
+    ],
+    "".NETPlatform,Version=v5.0"": []
+  }
+}
+";
+
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            // TODO(anurse): We should be mocking this out or using a stable source...
+            sources.Add(new PackageSource("https://www.myget.org/F/dotnet-core/api/v2/"));
+
+            var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
+            var projectDir = TestFileSystemUtility.CreateRandomTestFolder();
+            _testFolders.Add(packagesDir);
+            _testFolders.Add(projectDir);
+
+            var specPath = Path.Combine(projectDir, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(project, "TestProject", specPath);
+
+            var lockFileFormat = new LockFileFormat();
+            var lockFile = lockFileFormat.Parse(lockFileContent);
+            Assert.True(lockFile.IsLocked); // Just to make sure no-one accidentally unlocks it :)
+
+            var request = new RestoreRequest(spec, sources, packagesDir);
+            request.MaxDegreeOfConcurrency = 1;
+            request.WriteLockFile = false;
+            request.ExistingLockFile = lockFile;
+
+            // Act
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger, request);
+            var result = await command.ExecuteAsync();
+            var installed = result.GetAllInstalled();
+
+            // Assert
+            Assert.Equal(1, installed.Count);
+            Assert.Equal("System.Runtime", installed.Single().Name);
+            Assert.Equal(4, installed.Single().Version.Major);
+            Assert.Equal(0, installed.Single().Version.Minor);
+            Assert.Equal(20, installed.Single().Version.Patch);
+            // Don't assert the pre-release tag since it may vary
         }
 
         private static List<LockFileItem> GetRuntimeAssemblies(IList<LockFileTarget> targets, string framework, string runtime)

--- a/test/NuGet.DependencyResolver.Core.Tests/ResolverFacts.cs
+++ b/test/NuGet.DependencyResolver.Core.Tests/ResolverFacts.cs
@@ -43,7 +43,8 @@ namespace NuGet.DependencyResolver.Core.Tests
             },
             NuGetFramework.Parse("net45"),
             runtimeIdentifier: null,
-            runtimeGraph: null);
+            runtimeGraph: null,
+            recursive: true);
 
             Assert.NotNull(result.Item.Data.Match);
             Assert.NotNull(result.Item.Data.Match.Library);
@@ -82,7 +83,8 @@ namespace NuGet.DependencyResolver.Core.Tests
             },
             NuGetFramework.Parse("net45"),
             runtimeIdentifier: null,
-            runtimeGraph: null);
+            runtimeGraph: null,
+            recursive: true);
 
             Assert.NotNull(result.Item.Data.Match);
             Assert.NotNull(result.Item.Data.Match.Library);


### PR DESCRIPTION
fixes NuGet/Home#622

To test it out:
1. Clone this repo (if you don't already have it)
2. `git checkout anurse/622-lock-dat-file`
3. `.\build`
4. `cd misc\RestoreTests\LockedLockFile`
5. Clear your `%USERPROFILE%\.nuget\packages` directory
6. Run `..\..\..\nuget3 restore --source https://www.myget.org/F/dotnet-core/api/v2`

The expected result is that, **despite** the `*` in project.json and the fact that there are higher versions on the feed, only versions `4.0.x-beta-22927` are restored.

/cc @davidfowl @lodejard @ericstj @emgarten @yishaigalatzer 
