### PR TITLE
fix NuGet/Home#831 by skipping the compat check when there are unresolved packages

### DIFF
--- a/src/NuGet.Commands/RestoreCommand.cs
+++ b/src/NuGet.Commands/RestoreCommand.cs
@@ -76,22 +76,25 @@ namespace NuGet.Commands
                 lockFile.IsLocked = relockFile;
             }
 
-            // Scan every graph for compatibility
+            // Scan every graph for compatibility, as long as there were no unresolved packages
             var checkResults = new List<CompatibilityCheckResult>();
-            var checker = new CompatibilityChecker(localRepository, lockFile, _log);
-            foreach (var graph in graphs)
+            if (graphs.All(g => !g.Unresolved.Any()))
             {
-                _log.LogVerbose(Strings.FormatLog_CheckingCompatibility(graph.Name));
-                var res = checker.Check(graph);
-                _success &= res.Success;
-                checkResults.Add(res);
-                if (res.Success)
+                var checker = new CompatibilityChecker(localRepository, lockFile, _log);
+                foreach (var graph in graphs)
                 {
-                    _log.LogInformation(Strings.FormatLog_PackagesAreCompatible(graph.Name));
-                }
-                else
-                {
-                    _log.LogError(Strings.FormatLog_PackagesIncompatible(graph.Name));
+                    _log.LogVerbose(Strings.FormatLog_CheckingCompatibility(graph.Name));
+                    var res = checker.Check(graph);
+                    _success &= res.Success;
+                    checkResults.Add(res);
+                    if (res.Success)
+                    {
+                        _log.LogInformation(Strings.FormatLog_PackagesAreCompatible(graph.Name));
+                    }
+                    else
+                    {
+                        _log.LogError(Strings.FormatLog_PackagesIncompatible(graph.Name));
+                    }
                 }
             }
 
@@ -249,7 +252,7 @@ namespace NuGet.Commands
             }
 
             // Walk additional runtime graphs for supports checks
-            if (_request.CompatibilityProfiles.Any())
+            if (_success && _request.CompatibilityProfiles.Any())
             {
                 var checkTasks = new List<Task<RestoreTargetGraph>>();
                 foreach (var profile in _request.CompatibilityProfiles.Where(p => !runtimeProfiles.Contains(p)))

--- a/src/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Commands/Strings.resx
@@ -145,7 +145,7 @@
     <value>{0} {1} is not compatible with {2}.</value>
   </data>
   <data name="Log_PackagesAreCompatible" xml:space="preserve">
-    <value>All packages are compatibile with {0}.</value>
+    <value>All packages are compatible with {0}.</value>
   </data>
   <data name="Log_PackagesIncompatible" xml:space="preserve">
     <value>Some packages are not compatible with {0}.</value>

--- a/test/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -328,6 +328,8 @@ namespace NuGet.Commands.Test
             Assert.False(result.Success);
 
             Assert.Equal(1, logger.Errors);
+            Assert.Empty(result.CompatibilityCheckResults);
+            Assert.DoesNotContain("compatible with", logger.Messages);
             Assert.Equal(1, unresolved.Count);
             Assert.Equal(0, installed.Count);
         }


### PR DESCRIPTION
We now skip the compat check if there are unresolved packages, since the results will be invalid. This reduces error spew

Fixes NuGet/Home#831

/cc @emgarten @yishaigalatzer 
