### PR TITLE
fix NuGet/Home#716 by adding a warning when a dependency is bumped up

### DIFF
--- a/misc/RestoreTests/BumpYouUp/project.json
+++ b/misc/RestoreTests/BumpYouUp/project.json
@@ -1,0 +1,8 @@
+{
+    "dependencies": {
+        "Newtonsoft.Json": "7.0.0"
+    },
+    "frameworks": {
+        "netcore50": { }
+    }
+}

--- a/src/NuGet.Commands/Properties/Strings.Designer.cs
+++ b/src/NuGet.Commands/Properties/Strings.Designer.cs
@@ -410,6 +410,22 @@ namespace NuGet.Commands
             return GetString("Log_LockFileOutOfDate");
         }
 
+        /// <summary>
+        /// Dependency specified was {0} {1} but ended up with {2} {3}.
+        /// </summary>
+        internal static string Log_DependencyBumpedUp
+        {
+            get { return GetString("Log_DependencyBumpedUp"); }
+        }
+
+        /// <summary>
+        /// Dependency specified was {0} {1} but ended up with {2} {3}.
+        /// </summary>
+        internal static string FormatLog_DependencyBumpedUp(object p0, object p1, object p2, object p3)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Log_DependencyBumpedUp"), p0, p1, p2, p3);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Commands/Strings.resx
@@ -192,4 +192,7 @@
   <data name="Log_LockFileOutOfDate" xml:space="preserve">
     <value>The lock file is out-of-date relative to the project file. Regenerating the lock file and re-locking.</value>
   </data>
+  <data name="Log_DependencyBumpedUp" xml:space="preserve">
+    <value>Dependency specified was {0} {1} but ended up with {2} {3}.</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes NuGet/Home#716

Simple warning that just tells the user if a dependency is bumped up from what was specified in the original project.json.

/cc @emgarten @yishaigalatzer 
