### PR TITLE
RestoreCommand performance improvements

### DIFF
--- a/src/NuGet.Commands/CompatilibityChecker.cs
+++ b/src/NuGet.Commands/CompatilibityChecker.cs
@@ -189,10 +189,11 @@ namespace NuGet.Commands
                 if (targetLibrary == null)
                 {
                     targetLibrary = LockFileUtils.CreateLockFileTargetLibrary(
-                        package,
-                        graph,
-                        new VersionFolderPathResolver(_localRepository.RepositoryRoot),
-                        libraryId.Name);
+                        library: null,
+                        package: package,
+                        targetGraph: graph,
+                        defaultPackagePathResolver: new VersionFolderPathResolver(_localRepository.RepositoryRoot),
+                        correctedPackageName: libraryId.Name);
                 }
 
                 return new CompatibilityData(files, targetLibrary);

--- a/src/NuGet.DependencyResolver.Core/LibraryRangeCacheKey.cs
+++ b/src/NuGet.DependencyResolver.Core/LibraryRangeCacheKey.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.Versioning;
+
+namespace NuGet.DependencyResolver
+{
+    /// <summary>
+    /// Helper class to hold a library range and framework.
+    /// </summary>
+    public class LibraryRangeCacheKey : IEquatable<LibraryRangeCacheKey>
+    {
+        public LibraryRangeCacheKey(LibraryRange range, NuGetFramework framework)
+        {
+            Framework = framework;
+            LibraryRange = range;
+        }
+
+        /// <summary>
+        /// Target framework
+        /// </summary>
+        public NuGetFramework Framework { get; }
+
+        /// <summary>
+        /// Library range information.
+        /// </summary>
+        public LibraryRange LibraryRange { get; }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as LibraryRangeCacheKey);
+        }
+
+        public override int GetHashCode()
+        {
+            var combiner = new HashCodeCombiner();
+
+            combiner.AddObject(LibraryRange);
+            combiner.AddObject(Framework);
+
+            return combiner.CombinedHash;
+        }
+
+        public bool Equals(LibraryRangeCacheKey other)
+        {
+            if (Object.ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            if (Object.ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            return LibraryRange.Equals(other.LibraryRange)
+                && Framework.Equals(other.Framework);
+        }
+
+        public override string ToString()
+        {
+            return string.Format(CultureInfo.InvariantCulture, "{0} {1}", LibraryRange, Framework);
+        }
+    }
+}

--- a/src/NuGet.DependencyResolver.Core/Remote/RemoteWalkContext.cs
+++ b/src/NuGet.DependencyResolver.Core/Remote/RemoteWalkContext.cs
@@ -1,7 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using NuGet.LibraryModel;
+using NuGet.Packaging.Core;
 
 namespace NuGet.DependencyResolver
 {
@@ -12,10 +16,23 @@ namespace NuGet.DependencyResolver
             ProjectLibraryProviders = new List<IRemoteDependencyProvider>();
             LocalLibraryProviders = new List<IRemoteDependencyProvider>();
             RemoteLibraryProviders = new List<IRemoteDependencyProvider>();
+
+            FindLibraryEntryCache = new ConcurrentDictionary<LibraryRangeCacheKey, Task<GraphItem<RemoteResolveResult>>>();
+            PackageFileCache = new ConcurrentDictionary<PackageIdentity, IList<string>>(PackageIdentity.Comparer);
         }
 
         public IList<IRemoteDependencyProvider> ProjectLibraryProviders { get; }
         public IList<IRemoteDependencyProvider> LocalLibraryProviders { get; }
         public IList<IRemoteDependencyProvider> RemoteLibraryProviders { get; }
+
+        /// <summary>
+        /// Library entry cache.
+        /// </summary>
+        public ConcurrentDictionary<LibraryRangeCacheKey, Task<GraphItem<RemoteResolveResult>>> FindLibraryEntryCache { get; }
+
+        /// <summary>
+        /// Files contained in a package.
+        /// </summary>
+        public ConcurrentDictionary<PackageIdentity, IList<string>> PackageFileCache { get; }
     }
 }


### PR DESCRIPTION
RestoreCommand performance improvements.
1. Reuse libraries from the previous lock file if the SHA is the same
2. Read the SHA512 from disk instead of hashing the nupkg
3. Read the nuspec from disk instead of from the nupkg during library target entry creation.
4. Download all nupkgs even if they are not used in the graph. This helps keep us from having to go online during the next lock file creation to find them again.
5. Cache runtime graphs
6. Store library file lists to avoid fetching them from disk multiple times. If the previous library can be reused the files are used from that.

//cc @davidfowl @anurse @yishaigalatzer 
