### PR TITLE
DotNet framework compatibility

### DIFF
--- a/src/NuGet.Frameworks/DefaultFrameworkMappings.cs
+++ b/src/NuGet.Frameworks/DefaultFrameworkMappings.cs
@@ -332,11 +332,68 @@ namespace NuGet.Frameworks
                                 new FrameworkRange(
                                     new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.WinRT, FrameworkConstants.EmptyVersion),
                                     new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.WinRT, new Version(4, 5, 0, 0)))),
+
+                            // Dotnet compatibility white list
+                            // net45 and up support dotnet
+                            new OneWayCompatibilityMappingEntry(
+                                new FrameworkRange(
+                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, new Version(4, 5, 0, 0)),
+                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.MaxVersion)),
+                                FrameworkConstants.DotNetAll),
+
+                            // dnx451 and up support dotnet
+                            new OneWayCompatibilityMappingEntry(
+                                new FrameworkRange(
+                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Dnx, new Version(4, 5, 1, 0)),
+                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Dnx, FrameworkConstants.MaxVersion)),
+                                FrameworkConstants.DotNetAll),
+
+                            // silverlight above version 5 supports dotnet
+                            new OneWayCompatibilityMappingEntry(
+                                new FrameworkRange(
+                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Silverlight, FrameworkConstants.Version5),
+                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Silverlight, FrameworkConstants.MaxVersion),
+                                    includeMin: false,
+                                    includeMax: true),
+                                FrameworkConstants.DotNetAll),
+
+                            // wp8 and up support dotnet
+                            new OneWayCompatibilityMappingEntry(
+                                new FrameworkRange(
+                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.WindowsPhone, new Version(8, 0, 0, 0)),
+                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.WindowsPhone, FrameworkConstants.MaxVersion)),
+                                FrameworkConstants.DotNetAll),
+
+                           // the below frameworks support dotnet
+                           CreateDotNetMappingForAllVersions(FrameworkConstants.FrameworkIdentifiers.DnxCore),
+                           CreateDotNetMappingForAllVersions(FrameworkConstants.FrameworkIdentifiers.MonoAndroid),
+                           CreateDotNetMappingForAllVersions(FrameworkConstants.FrameworkIdentifiers.MonoMac),
+                           CreateDotNetMappingForAllVersions(FrameworkConstants.FrameworkIdentifiers.MonoTouch),
+                           CreateDotNetMappingForAllVersions(FrameworkConstants.FrameworkIdentifiers.NetCore),
+                           CreateDotNetMappingForAllVersions(FrameworkConstants.FrameworkIdentifiers.UAP),
+                           CreateDotNetMappingForAllVersions(FrameworkConstants.FrameworkIdentifiers.Windows),
+                           CreateDotNetMappingForAllVersions(FrameworkConstants.FrameworkIdentifiers.WindowsPhoneApp),
+                           CreateDotNetMappingForAllVersions(FrameworkConstants.FrameworkIdentifiers.XamarinIOs),
+                           CreateDotNetMappingForAllVersions(FrameworkConstants.FrameworkIdentifiers.XamarinMac),
+                           CreateDotNetMappingForAllVersions(FrameworkConstants.FrameworkIdentifiers.XamarinPlayStation3),
+                           CreateDotNetMappingForAllVersions(FrameworkConstants.FrameworkIdentifiers.XamarinPlayStation4),
+                           CreateDotNetMappingForAllVersions(FrameworkConstants.FrameworkIdentifiers.XamarinPlayStationVita),
+                           CreateDotNetMappingForAllVersions(FrameworkConstants.FrameworkIdentifiers.XamarinXbox360),
+                           CreateDotNetMappingForAllVersions(FrameworkConstants.FrameworkIdentifiers.XamarinXboxOne),
                         };
                 }
 
                 return _compatibilityMappings;
             }
+        }
+
+        // Map the given framework to dotnet
+        private static OneWayCompatibilityMappingEntry CreateDotNetMappingForAllVersions(string framework)
+        {
+            return new OneWayCompatibilityMappingEntry(new FrameworkRange(
+                        new NuGetFramework(framework, FrameworkConstants.EmptyVersion),
+                        new NuGetFramework(framework, FrameworkConstants.MaxVersion)),
+                        FrameworkConstants.DotNetAll);
         }
 
         private static string[] _frameworkPrecedence;

--- a/src/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Frameworks/FrameworkConstants.cs
@@ -13,6 +13,9 @@ namespace NuGet.Frameworks
         public static readonly Version MaxVersion = new Version(Int32.MaxValue, 0, 0, 0);
         public static readonly Version Version5 = new Version(5, 0, 0, 0);
         public static readonly Version Version10 = new Version(10, 0, 0, 0);
+        public static readonly FrameworkRange DotNetAll = new FrameworkRange(
+                        new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetPlatform, FrameworkConstants.EmptyVersion),
+                        new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetPlatform, FrameworkConstants.MaxVersion));
 
         public static class SpecialIdentifiers
         {

--- a/src/NuGet.Frameworks/FrameworkRange.cs
+++ b/src/NuGet.Frameworks/FrameworkRange.cs
@@ -13,8 +13,16 @@ namespace NuGet.Frameworks
     {
         private readonly NuGetFramework _minFramework;
         private readonly NuGetFramework _maxFramework;
+        private readonly bool _includeMin;
+        private readonly bool _includeMax;
 
         public FrameworkRange(NuGetFramework min, NuGetFramework max)
+            : this(min, max, true, true)
+        {
+
+        }
+
+        public FrameworkRange(NuGetFramework min, NuGetFramework max, bool includeMin, bool includeMax)
         {
             if (min == null)
             {
@@ -33,6 +41,8 @@ namespace NuGet.Frameworks
 
             _minFramework = min;
             _maxFramework = max;
+            _includeMin = includeMin;
+            _includeMax = includeMax;
         }
 
         /// <summary>
@@ -52,6 +62,28 @@ namespace NuGet.Frameworks
         }
 
         /// <summary>
+        /// Minimum version inclusiveness.
+        /// </summary>
+        public bool IncludeMin
+        {
+            get
+            {
+                return _includeMin;
+            }
+        }
+
+        /// <summary>
+        /// Maximum version inclusiveness.
+        /// </summary>
+        public bool IncludeMax
+        {
+            get
+            {
+                return _includeMax;
+            }
+        }
+
+        /// <summary>
         /// Framework Identifier of both the Min and Max
         /// </summary>
         public string FrameworkIdentifier
@@ -65,13 +97,10 @@ namespace NuGet.Frameworks
         public bool Satisfies(NuGetFramework framework)
         {
             return SameExceptForVersion(_minFramework, framework)
-                   && _minFramework.Version <= framework.Version
-                   && _maxFramework.Version >= framework.Version;
-
-            // TODO: platform version check?
+                && (_includeMin ? _minFramework.Version <= framework.Version : _minFramework.Version < framework.Version)
+                && (_includeMax ? _maxFramework.Version >= framework.Version : _maxFramework.Version > framework.Version);
         }
 
-        // TODO: should the range be 2D and work on both framework and platform versions?
         private static bool SameExceptForVersion(NuGetFramework x, NuGetFramework y)
         {
             return StringComparer.OrdinalIgnoreCase.Equals(x.Framework, y.Framework)

--- a/src/NuGet.Frameworks/comparers/FrameworkRangeComparer.cs
+++ b/src/NuGet.Frameworks/comparers/FrameworkRangeComparer.cs
@@ -26,7 +26,8 @@ namespace NuGet.Frameworks
             }
 
             return StringComparer.OrdinalIgnoreCase.Equals(x.FrameworkIdentifier, y.FrameworkIdentifier) &&
-                   NuGetFramework.Comparer.Equals(x.Min, y.Min) && NuGetFramework.Comparer.Equals(x.Max, y.Max);
+                   NuGetFramework.Comparer.Equals(x.Min, y.Min) && NuGetFramework.Comparer.Equals(x.Max, y.Max)
+                   && x.IncludeMin == y.IncludeMin && x.IncludeMax == y.IncludeMax;
         }
 
         public int GetHashCode(FrameworkRange obj)
@@ -41,6 +42,8 @@ namespace NuGet.Frameworks
             combiner.AddStringIgnoreCase(obj.FrameworkIdentifier);
             combiner.AddObject(obj.Min);
             combiner.AddObject(obj.Max);
+            combiner.AddObject(obj.IncludeMin);
+            combiner.AddObject(obj.IncludeMax);
 
             return combiner.CombinedHash;
         }

--- a/test/NuGet.Frameworks.Test/CompatibilityTests.cs
+++ b/test/NuGet.Frameworks.Test/CompatibilityTests.cs
@@ -138,11 +138,8 @@ namespace NuGet.Test
         [InlineData("win81", "netcore50")]
         [InlineData("wpa81", "netcore50")]
         [InlineData("uap10.0", "portable-net45+sl5+wp8")]
-        [InlineData("netcore451", "dotnet")]
         [InlineData("win8", "netcore451")]
-        [InlineData("netcore451", "dotnet")]
-        [InlineData("win81", "dotnet")]
-        [InlineData("wpa81", "dotnet")]
+        [InlineData("net40", "dotnet")]
         public void Compatibility_SimpleNonCompat(string fw1, string fw2)
         {
             var framework1 = NuGetFramework.Parse(fw1);
@@ -212,23 +209,38 @@ namespace NuGet.Test
         }
 
         [Theory]
-        [InlineData("net45")]
-        [InlineData("netcore45")]
-        [InlineData("win8")]
+        [InlineData("net40-client")]
+        [InlineData("net40")]
         [InlineData("native")]
-        [InlineData("dnx451")]
+        [InlineData("sl5")]
+        [InlineData("wp7")]
+        [InlineData("wp4")]
+        [InlineData("sl")]
+        [InlineData("netmf")]
+        [InlineData("net35")]
+        [InlineData("net403")]
         [InlineData("portable-net45+win8")]
-        public void Compatibility_DotNetNeg(string framework)
+        [InlineData("net45-cf")]
+        [InlineData("sl5")]
+        [InlineData("sl")]
+        [InlineData("netmf")]
+        [InlineData("wp7")]
+        [InlineData("net40")]
+        public void Compatibility_ProjectCannotInstallDotNetLibraries(string framework)
         {
+            // Arrange
             var framework1 = NuGetFramework.Parse(framework);
             var framework2 = NuGetFramework.Parse("dotnet");
-
             var compat = DefaultCompatibilityProvider.Instance;
 
+            // Act & Assert
             Assert.False(compat.IsCompatible(framework1, framework2));
         }
 
         [Theory]
+        [InlineData("net45")]
+        [InlineData("net45-client")]
+        [InlineData("net451")]
         [InlineData("net50")]
         [InlineData("net46")]
         [InlineData("dnx46")]
@@ -237,12 +249,36 @@ namespace NuGet.Test
         [InlineData("dnxcore")]
         [InlineData("netcore50")]
         [InlineData("netcore60")]
-        public void Compatibility_DotNetCompat(string framework)
+        [InlineData("uap")]
+        [InlineData("uap11.0")]
+        [InlineData("wpa")]
+        [InlineData("wpa81")]
+        [InlineData("netcore")]
+        [InlineData("win")]
+        [InlineData("win8")]
+        [InlineData("win81")]
+        [InlineData("monotouch")]
+        [InlineData("monotouch10")]
+        [InlineData("monoandroid")]
+        [InlineData("monoandroid40")]
+        [InlineData("monomac")]
+        [InlineData("xamarinios")]
+        [InlineData("xamarinmac")]
+        [InlineData("xamarinpsthree")]
+        [InlineData("xamarinpsfour")]
+        [InlineData("xamarinpsvita")]
+        [InlineData("xamarinxboxthreesixty")]
+        [InlineData("xamarinxboxone")]
+        [InlineData("sl6")]
+        public void Compatibility_ProjectCanInstallDotNetLibraries(string framework)
         {
+            // Arrange
             var framework1 = NuGetFramework.Parse(framework);
             var framework2 = NuGetFramework.Parse("dotnet");
 
             var compat = DefaultCompatibilityProvider.Instance;
+
+            // Act & Assert
 
             // verify that compatibility is inferred across all the mappings
             Assert.True(compat.IsCompatible(framework1, framework2));
@@ -250,7 +286,6 @@ namespace NuGet.Test
             // verify that this was a one way mapping
             Assert.True(!compat.IsCompatible(framework2, framework1));
         }
-
 
         [Theory]
         [InlineData("dotnet")]

--- a/test/NuGet.Frameworks.Test/FrameworkExpanderTests.cs
+++ b/test/NuGet.Frameworks.Test/FrameworkExpanderTests.cs
@@ -66,9 +66,12 @@ namespace NuGet.Test
             FrameworkExpander expander = new FrameworkExpander();
             var expanded = expander.Expand(framework).ToArray();
 
-            Assert.Equal(2, expanded.Length);
+            Assert.Equal(5, expanded.Length);
             Assert.Equal(".NETFramework,Version=v4.5,Profile=Client", expanded[0].ToString());
             Assert.Equal(".NETFramework,Version=v4.5,Profile=Full", expanded[1].ToString());
+            Assert.Equal(".NETPlatform,Version=v5.0", expanded[2].ToString()); // dotnet5
+            Assert.Equal(".NETPlatform,Version=v2147483647.0", expanded[3].ToString());
+            Assert.Equal(".NETPlatform,Version=v5.0", expanded[4].ToString());  // dotnet
         }
 
         [Fact]
@@ -79,7 +82,7 @@ namespace NuGet.Test
             FrameworkExpander expander = new FrameworkExpander();
             var expanded = expander.Expand(framework).ToArray();
 
-            Assert.Equal<int>(5, expanded.Length);
+            Assert.Equal<int>(8, expanded.Length);
         }
 
         [Fact]

--- a/test/NuGet.Frameworks.Test/FrameworkRangeTests.cs
+++ b/test/NuGet.Frameworks.Test/FrameworkRangeTests.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NuGet.Frameworks
+{
+    public class FrameworkRangeTests
+    {
+        [Theory]
+        [InlineData("net45")]
+        [InlineData("net20")]
+        [InlineData("net")]
+        [InlineData("net451")]
+        [InlineData("net40")]
+        public void FrameworkRange_BasicSatisfies(string framework)
+        {
+            // Arrange
+            var test = NuGetFramework.ParseFolder(framework);
+            var range = new FrameworkRange(NuGetFramework.ParseFolder("net"), NuGetFramework.ParseFolder("net451"));
+
+            // Act & Assert
+            Assert.True(range.Satisfies(test));
+        }
+
+        [Theory]
+        [InlineData("dotnet")]
+        [InlineData("dnx452")]
+        [InlineData("net452")]
+        [InlineData("net20")]
+        [InlineData("net")]
+        public void FrameworkRange_BasicDoesNotSatisfy(string framework)
+        {
+            // Arrange
+            var test = NuGetFramework.ParseFolder(framework);
+            var range = new FrameworkRange(NuGetFramework.ParseFolder("net35"), NuGetFramework.ParseFolder("net451"));
+
+            // Act & Assert
+            Assert.False(range.Satisfies(test));
+        }
+
+        [Theory]
+        [InlineData("dotnet")]
+        [InlineData("dnx452")]
+        [InlineData("dnx451")]
+        [InlineData("net452")]
+        [InlineData("net35")]
+        [InlineData("net20")]
+        [InlineData("net")]
+        public void FrameworkRange_BasicDoesNotSatisfyExclusive(string framework)
+        {
+            // Arrange
+            var test = NuGetFramework.ParseFolder(framework);
+            var range = new FrameworkRange(
+                NuGetFramework.ParseFolder("net35"), 
+                NuGetFramework.ParseFolder("net451"),
+                includeMin: false,
+                includeMax: false);
+
+            // Act & Assert
+            Assert.False(range.Satisfies(test));
+        }
+
+        [Theory]
+        [InlineData("net45")]
+        [InlineData("net36")]
+        [InlineData("net40")]
+        public void FrameworkRange_BasicSatisfiesExclusive(string framework)
+        {
+            // Arrange
+            var test = NuGetFramework.ParseFolder(framework);
+            var range = new FrameworkRange(
+                NuGetFramework.ParseFolder("net35"),
+                NuGetFramework.ParseFolder("net451"),
+                includeMin: false,
+                includeMax: false);
+
+            // Act & Assert
+            Assert.True(range.Satisfies(test));
+        }
+
+        [Fact]
+        public void FrameworkRange_HashCodeDiffersOnExlusiveness()
+        {
+            // Arrange
+            var range1 = new FrameworkRange(
+                NuGetFramework.ParseFolder("net35"),
+                NuGetFramework.ParseFolder("net451"),
+                includeMin: false,
+                includeMax: false);
+
+            var range2 = new FrameworkRange(
+                NuGetFramework.ParseFolder("net35"),
+                NuGetFramework.ParseFolder("net451"),
+                includeMin: true,
+                includeMax: false);
+
+            var range3 = new FrameworkRange(
+                NuGetFramework.ParseFolder("net35"),
+                NuGetFramework.ParseFolder("net451"),
+                includeMin: true,
+                includeMax: true);
+
+            var range4 = new FrameworkRange(
+                NuGetFramework.ParseFolder("net35"),
+                NuGetFramework.ParseFolder("net451"),
+                includeMin: false,
+                includeMax: true);
+
+            // Act
+            // Find the unique set of hash codes
+            var hashCodes = new HashSet<int>()
+            {
+                range1.GetHashCode(),
+                range2.GetHashCode(),
+                range3.GetHashCode(),
+                range4.GetHashCode(),
+            };
+
+            // Assert
+            Assert.Equal(4, hashCodes.Count);
+            Assert.NotEqual(range1, range2);
+            Assert.NotEqual(range1, range3);
+            Assert.NotEqual(range1, range4);
+            Assert.NotEqual(range2, range4);
+            Assert.NotEqual(range2, range3);
+            Assert.NotEqual(range3, range4);
+        }
+    }
+}


### PR DESCRIPTION
This change adds support for installing packages with 'dotnet' libraries into projects with known TxMs except for a set of  explicitly incompatible ones such as net40, sl5, wp7, native.

https://github.com/NuGet/Home/issues/768

//cc @davidfowl @anurse @yishaigalatzer 
