### PR TITLE
fix NuGet/Home#869 by setting a convention for satellite assemblies

### DIFF
--- a/src/NuGet.Client/ManagedCodeConventions.cs
+++ b/src/NuGet.Client/ManagedCodeConventions.cs
@@ -35,6 +35,7 @@ namespace NuGet.Client
             parser: o => o.Equals("_._", StringComparison.Ordinal) ? o : null, // Accept "_._" as a pseudo-assembly
             fileExtensions: new[] { ".dll" });
         private static readonly ContentPropertyDefinition MSBuildProperty = new ContentPropertyDefinition(PropertyNames.MSBuild, fileExtensions: new[] { ".targets", ".props" });
+        private static readonly ContentPropertyDefinition SatelliteAssemblyProperty = new ContentPropertyDefinition(PropertyNames.SatelliteAssembly, fileExtensions: new[] { ".resources.dll" });
 
         private RuntimeGraph _runtimeGraph;
 
@@ -52,6 +53,7 @@ namespace NuGet.Client
             props[AssemblyProperty.Name] = AssemblyProperty;
             props[LocaleProperty.Name] = LocaleProperty;
             props[MSBuildProperty.Name] = MSBuildProperty;
+            props[SatelliteAssemblyProperty.Name] = SatelliteAssemblyProperty;
 
             props[PropertyNames.RuntimeIdentifier] = new ContentPropertyDefinition(
                 PropertyNames.RuntimeIdentifier,
@@ -316,8 +318,8 @@ namespace NuGet.Client
                     },
                     pathPatterns: new PatternDefinition[]
                     {
-                        "runtimes/{rid}/lib/{tfm}/{locale}/{resources}",
-                        "lib/{tfm}/{locale}/{resources}"
+                        "runtimes/{rid}/lib/{tfm}/{locale}/{satelliteAssembly}",
+                        "lib/{tfm}/{locale}/{satelliteAssembly}"
                     });
 
                 MSBuildFiles = new PatternSet(
@@ -349,6 +351,7 @@ namespace NuGet.Client
             public static readonly string ManagedAssembly = "assembly";
             public static readonly string Locale = "locale";
             public static readonly string MSBuild = "msbuild";
+            public static readonly string SatelliteAssembly = "satelliteAssembly";
         }
     }
 }

--- a/test/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -418,6 +418,48 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
+        public async Task RestoreCommand_CanInstallPackageWithSatelliteAssemblies()
+        {
+            const string project = @"
+{
+    ""dependencies"": {
+        ""Microsoft.OData.Client"": ""6.12.0"",
+    },
+    ""frameworks"": {
+        ""net40"": {}
+    }
+}
+";
+
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            sources.Add(new PackageSource("https://www.nuget.org/api/v2"));
+
+            var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
+            var projectDir = TestFileSystemUtility.CreateRandomTestFolder();
+            _testFolders.Add(packagesDir);
+            _testFolders.Add(projectDir);
+
+            var specPath = Path.Combine(projectDir, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(project, "TestProject", specPath);
+
+            var request = new RestoreRequest(spec, sources, packagesDir);
+            request.MaxDegreeOfConcurrency = 1;
+            request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
+
+            var lockFileFormat = new LockFileFormat();
+
+            // Act
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger, request);
+            var result = await command.ExecuteAsync();
+
+            // Assert
+            Assert.True(result.Success);
+        }
+
+        [Fact]
         public async Task RestoreCommand_UnmatchedRefAndLibAssemblies()
         {
             const string project = @"


### PR DESCRIPTION
Fixes NuGet/Home#869

I renamed the `resources` convention to `satelliteAssembly` to better match the existing `assembly` convention. Then, I actually implemented it :)
