### PR TITLE
Do not add empty lines when attempting to preserve formatting that ap…cd 

### DIFF
--- a/src/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Configuration/Settings/Settings.cs
@@ -519,9 +519,15 @@ namespace NuGet.Configuration
                 }
             }
 
-            foreach (var element in nodesToRemove)
+            // Special case for the scenario where the clear element is the last element in the
+            // section (followed by whitespace and comments). In this case, we can avoid removing any
+            // node and preserving the original formatting.
+            if (nodesToRemove.Any(node => node.NodeType == XmlNodeType.Element))
             {
-                element.Remove();
+                foreach (var element in nodesToRemove)
+                {
+                    element.Remove();
+                }
             }
         }
 

--- a/src/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Configuration/Settings/Settings.cs
@@ -472,6 +472,8 @@ namespace NuGet.Configuration
                 sectionElement = GetOrCreateSection(ConfigXDocument.Root, section);
             }
 
+            // When updating attempt to preserve the clear tag (and any sources that appear prior to it)
+            // to avoid creating extra diffs in the source.
             RemoveElementAfterClearTag(sectionElement);
 
             foreach (var value in valuesToWrite)
@@ -496,20 +498,28 @@ namespace NuGet.Configuration
                 return;
             }
 
-            var removeElmentList = new List<XElement>();
-            foreach (var element in sectionElement.Elements())
+            var nodesToRemove = new List<XNode>();
+            foreach (var node in sectionElement.Nodes())
             {
+                if (node.NodeType != XmlNodeType.Element)
+                {
+                    nodesToRemove.Add(node);
+                    continue;
+                }
+
+                var element = (XElement)node;
+
                 if (element.Name.LocalName.Equals("clear", StringComparison.OrdinalIgnoreCase))
                 {
-                    removeElmentList.Clear();
+                    nodesToRemove.Clear();
                 }
                 else 
                 {
-                    removeElmentList.Add(element);
+                    nodesToRemove.Add(element);
                 }
             }
 
-            foreach (var element in removeElmentList)
+            foreach (var element in nodesToRemove)
             {
                 element.Remove();
             }

--- a/test/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -799,11 +799,12 @@ namespace NuGet.Configuration.Test
                        @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
-        <clear />
+        <clear /> 
         <add key=""test3"" value=""https://test3.net"" />
     </packageSources>
     <disabledPackageSources>
-        <clear /></disabledPackageSources>
+        <clear />
+    </disabledPackageSources>
 </configuration>
 ",
                    File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config")));
@@ -866,7 +867,8 @@ namespace NuGet.Configuration.Test
 <configuration>
   <packageSources>
     <add key=""key1"" value=""https://test.org/1"" /> 
-    <clear /></packageSources>
+    <clear />   
+  </packageSources>
 </configuration>",
                   File.ReadAllText(Path.Combine(mockBaseDirectory.Path, @"dir1\NuGet.config")));
             }

--- a/test/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -642,7 +642,7 @@ namespace NuGet.Configuration.Test
 #else
             string appDataPath = Environment.GetEnvironmentVariable("AppData");
 #endif
-            var configFileContent = TestFilesystemUtility.ReadConfigurationFile(Path.Combine(appDataPath, @"NuGet\NuGet.config"));
+            var configFileContent = File.ReadAllText(Path.Combine(appDataPath, @"NuGet\NuGet.config"));
             var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageSources>
@@ -655,11 +655,11 @@ namespace NuGet.Configuration.Test
   </disabledPackageSources>
 </configuration>";
 
-            Assert.Equal(TestFilesystemUtility.FormatXmlString(result), configFileContent);
+            Assert.Equal(result, configFileContent);
         }
 
         [Fact]
-        public void SavePackageSourcesWithOneCLear()
+        public void SavePackageSourcesWithOneClear()
         {
             using (var mockBaseDirectory = TestFilesystemUtility.CreateRandomTestFolder())
             {
@@ -693,20 +693,19 @@ namespace NuGet.Configuration.Test
 
                 // Assert
                 Assert.Equal(
-                   TestFilesystemUtility.FormatXmlString(
                        @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
         <add key=""nuget.org"" value=""https://nuget.org"" />
-        <add key=""test.org"" value=""https://test.org"" />
-        <clear />
+        <add key=""test.org"" value=""https://test.org"" /> 
+         <clear />
         <add key=""test.org"" value=""https://new.test.org"" protocolVersion=""3"" />
         <add key=""test2"" value=""https://test2.net"" />
         <add key=""test3"" value=""https://test3.net"" />
     </packageSources>
 </configuration>
-"),
-                   TestFilesystemUtility.FormatXmlString(File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config"))));
+",
+                   File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config")));
             }
         }
 
@@ -746,21 +745,20 @@ namespace NuGet.Configuration.Test
 
                 // Assert
                 Assert.Equal(
-                   TestFilesystemUtility.FormatXmlString(
                        @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
         <add key=""nuget.org"" value=""https://nuget.org"" />
-        <add key=""test.org"" value=""https://test.org"" />
-        <clear />
+        <add key=""test.org"" value=""https://test.org"" /> 
+        <clear /> 
         <add key=""test.org"" value=""https://new.test.org"" protocolVersion=""3"" />
         <clear />
         <add key=""test2"" value=""https://test2.net"" />
         <add key=""test3"" value=""https://test3.net"" />
     </packageSources>
 </configuration>
-"),
-                   TestFilesystemUtility.FormatXmlString(File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config"))));
+",
+                   File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config")));
             }
         }
 
@@ -798,19 +796,17 @@ namespace NuGet.Configuration.Test
 
                 // Assert
                 Assert.Equal(
-                   TestFilesystemUtility.FormatXmlString(
                        @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
-        <clear /> 
+        <clear />
         <add key=""test3"" value=""https://test3.net"" />
     </packageSources>
     <disabledPackageSources>
-        <clear />
-    </disabledPackageSources>
+        <clear /></disabledPackageSources>
 </configuration>
-"),
-                   TestFilesystemUtility.FormatXmlString(File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config"))));
+",
+                   File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config")));
             }
         }
 
@@ -824,7 +820,8 @@ namespace NuGet.Configuration.Test
                 var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageSources>
-    <clear /> <!-- i.e. ignore values from prior conf files -->
+    <!-- i.e. ignore values from prior conf files -->
+    <clear />
     <add key=""key2"" value=""https://test.org/2"" />
   </packageSources>
 </configuration>";
@@ -853,27 +850,25 @@ namespace NuGet.Configuration.Test
 
                 // Assert
                 Assert.Equal(
-                   TestFilesystemUtility.FormatXmlString(
                        @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageSources>
-    <clear /> <!-- i.e. ignore values from prior conf files -->
-       <add key=""key2"" value=""https://test.org/2"" />
+    <!-- i.e. ignore values from prior conf files -->
+    <clear />
+    <add key=""key2"" value=""https://test.org/2"" />
     <add key=""test3"" value=""https://test3.net"" />
   </packageSources>
-</configuration>"),
-                   TestFilesystemUtility.FormatXmlString(File.ReadAllText(Path.Combine(mockBaseDirectory.Path, @"dir1\dir2\NuGet.config"))));
+</configuration>",
+                   File.ReadAllText(Path.Combine(mockBaseDirectory.Path, @"dir1\dir2\NuGet.config")));
 
                 Assert.Equal(
-                  TestFilesystemUtility.FormatXmlString(
                      @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageSources>
     <add key=""key1"" value=""https://test.org/1"" /> 
-     <clear />   
-  </packageSources>
-</configuration>"),
-                  TestFilesystemUtility.FormatXmlString(File.ReadAllText(Path.Combine(mockBaseDirectory.Path, @"dir1\NuGet.config"))));
+    <clear /></packageSources>
+</configuration>",
+                  File.ReadAllText(Path.Combine(mockBaseDirectory.Path, @"dir1\NuGet.config")));
             }
         }
 
@@ -1795,18 +1790,19 @@ namespace NuGet.Configuration.Test
                 packageSourceProvider.SavePackageSources(sources);
 
                 // Assert - 3
-                Assert.Equal(TestFilesystemUtility.FormatXmlString(config2Contents),
-                    TestFilesystemUtility.FormatXmlString(File.ReadAllText(Path.Combine(rootPath, "NuGet.config"))));
+                Assert.Equal(config2Contents, File.ReadAllText(Path.Combine(rootPath, "NuGet.config")));
                 Assert.Equal(
-                    TestFilesystemUtility.FormatXmlString(
                         @"<?xml version=""1.0"" encoding=""utf-8""?>
-<configuration>  <packageSources>    <add key=""NuGet.org"" value=""https://NuGet.org"" />  </packageSources>
+<configuration>
+<packageSources>
+ <add key=""NuGet.org"" value=""https://NuGet.org"" />
+</packageSources>
   <disabledPackageSources>
     <add key=""NuGet.org"" value=""true"" />
   </disabledPackageSources>
 </configuration>
-"),
-                    TestFilesystemUtility.FormatXmlString(File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config"))));
+",
+                    File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config")));
             }
         }
 
@@ -1865,18 +1861,20 @@ namespace NuGet.Configuration.Test
                 packageSourceProvider.SavePackageSources(sources);
 
                 // Assert - 2
-                Assert.Equal(TestFilesystemUtility.FormatXmlString(config1Contents),
-                    TestFilesystemUtility.FormatXmlString(File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config"))));
+                Assert.Equal(config1Contents, File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config")));
                 Assert.Equal(
-                    TestFilesystemUtility.FormatXmlString(
                         @"<?xml version=""1.0"" encoding=""utf-8""?>
-<configuration>  <packageSources>       <add key=""test.org"" value=""https://test.org"" />    <add key=""NuGet.org"" value=""https://NuGet.org"" />  </packageSources>
+<configuration>
+<packageSources>
+ <add key=""test.org"" value=""https://test.org"" />
+ <add key=""NuGet.org"" value=""https://NuGet.org"" />
+</packageSources>
   <disabledPackageSources>
     <add key=""NuGet.org"" value=""true"" />
   </disabledPackageSources>
 </configuration>
-"),
-                    TestFilesystemUtility.FormatXmlString(File.ReadAllText(Path.Combine(rootPath, "NuGet.config"))));
+",
+                    File.ReadAllText(Path.Combine(rootPath, "NuGet.config")));
             }
         }
 
@@ -1938,20 +1936,22 @@ namespace NuGet.Configuration.Test
 
                 // Assert - 2
                 Assert.Equal(
-                    TestFilesystemUtility.FormatXmlString(
                         @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>  <packageSources>    <add key=""NuGet.org"" value=""https://new.NuGet.org"" />  </packageSources>
 </configuration>
-"),
-                    TestFilesystemUtility.FormatXmlString(File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config"))));
+",
+                    File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config")));
 
                 Assert.Equal(
-                    TestFilesystemUtility.FormatXmlString(
-                        @"<?xml version=""1.0"" encoding=""utf-8""?>
-<configuration>  <packageSources>    <add key=""NuGet.org"" value=""https://new.NuGet.org"" />    <add key=""test.org"" value=""https://test.org"" />  </packageSources>
+                         @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+<packageSources>
+ <add key=""NuGet.org"" value=""https://new.NuGet.org"" />
+ <add key=""test.org"" value=""https://test.org"" />
+</packageSources>
 </configuration>
-"),
-                    TestFilesystemUtility.FormatXmlString(File.ReadAllText(Path.Combine(rootPath, "NuGet.config"))));
+",
+                    File.ReadAllText(Path.Combine(rootPath, "NuGet.config")));
             }
         }
 
@@ -2009,29 +2009,27 @@ namespace NuGet.Configuration.Test
                 sources.Insert(1, new PackageSource("http://newsource", "NewSourceName"));
 
                 packageSourceProvider.SavePackageSources(sources);
-                
+
                 // Assert - 2
                 Assert.Equal(
-                    TestFilesystemUtility.FormatXmlString(
-                        @"<?xml version=""1.0"" encoding=""utf - 8""?>
-<configuration>  
-<packageSources>        
-<add key=""NewSourceName"" value=""http://newsource"" />    
-<add key=""test.org"" value=""https://test.org"" />  
-</packageSources>  
-<disabledPackageSources>    
-<add key=""test.org"" value=""true"" />  
-</disabledPackageSources></configuration>
-"),
-                    TestFilesystemUtility.FormatXmlString(File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config"))));
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>  <packageSources>    <add key=""NewSourceName"" value=""http://newsource"" />    <add key=""test.org"" value=""https://test.org"" />  </packageSources>
+  <disabledPackageSources>
+    <add key=""test.org"" value=""true"" />
+  </disabledPackageSources>
+</configuration>
+",
+                    File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config")));
 
                 Assert.Equal(
-                    TestFilesystemUtility.FormatXmlString(
                         @"<?xml version=""1.0"" encoding=""utf-8""?>
-<configuration>  <packageSources>    <add key=""NuGet.org"" value=""https://NuGet.org"" />  </packageSources>
+<configuration>
+<packageSources>
+ <add key=""NuGet.org"" value=""https://NuGet.org"" />
+</packageSources>
 </configuration>
-"),
-                    TestFilesystemUtility.FormatXmlString(File.ReadAllText(Path.Combine(rootPath, "NuGet.config"))));
+",
+                    File.ReadAllText(Path.Combine(rootPath, "NuGet.config")));
             }
         }
 
@@ -2097,18 +2095,17 @@ namespace NuGet.Configuration.Test
 
                 // Assert - 2
                 Assert.Equal(
-                    TestFilesystemUtility.FormatXmlString(
                         @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
-    <add key=""test.org"" value=""https://test.org"" />
-    <add key=""test.org"" value=""https://new2.test.org"" protocolVersion=""3"" />
-    <add key=""test2"" value=""https://test2.net"" />
-    <add key=""nuget.org"" value=""https://nuget.org"" />
-  </packageSources>
+        <add key=""test.org"" value=""https://test.org"" />
+        <add key=""test.org"" value=""https://new2.test.org"" protocolVersion=""3"" />
+        <add key=""test2"" value=""https://test2.net"" />
+        <add key=""nuget.org"" value=""https://nuget.org"" />
+    </packageSources>
 </configuration>
-"),
-                    TestFilesystemUtility.FormatXmlString(File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config"))));
+",
+                    File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config")));
             }
         }
 
@@ -2360,8 +2357,6 @@ namespace NuGet.Configuration.Test
 @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
-        
-        
         <add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" protocolVersion=""3"" />
         <add key=""nuget.org"" value=""https://nuget.org/api/v2"" />
         <add key=""Microsoft and .NET"" value=""https://www.nuget.org/api/v2/curated-feeds/microsoftdotnet/"" />
@@ -2410,7 +2405,6 @@ namespace NuGet.Configuration.Test
 @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
-        
         <add key=""Microsoft and .NET"" value=""https://www.nuget.org/api/v2/curated-feeds/microsoftdotnet/"" />
         <add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" protocolVersion=""3"" />
         <add key=""nuget.org"" value=""https://www.nuget.org/api/v2/"" />
@@ -2461,9 +2455,6 @@ namespace NuGet.Configuration.Test
 @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
-        
-        
-        
         <add key=""local"" value=""c:\users\testuser\.nuget"" />
         <add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" protocolVersion=""3"" />
         <add key=""nuget.org"" value=""http://not-nuget.org"" />

--- a/test/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Configuration.Test/SettingsTests.cs
@@ -358,7 +358,7 @@ namespace NuGet.Configuration.Test
     <add key=""key"" value=""value"" />
   </NewSectionName>
 </configuration>";
-            Assert.Equal(TestFilesystemUtility.FormatXmlString(result), TestFilesystemUtility.ReadConfigurationFile(Path.Combine(mockBaseDirectory, configFile)));
+            Assert.Equal(result, File.ReadAllText(Path.Combine(mockBaseDirectory, configFile)));
         }
 
         [Fact]
@@ -387,7 +387,7 @@ namespace NuGet.Configuration.Test
     <add key=""keyTwo"" value=""valueTwo"" />
   </SectionName>
 </configuration>";
-            Assert.Equal(TestFilesystemUtility.FormatXmlString(result), TestFilesystemUtility.ReadConfigurationFile(Path.Combine(mockBaseDirectory, configFile)));
+            Assert.Equal(result, File.ReadAllText(Path.Combine(mockBaseDirectory, configFile)));
         }
 
         [Fact]
@@ -415,7 +415,7 @@ namespace NuGet.Configuration.Test
     <add key=""key"" value=""NewValue"" />
   </SectionName>
 </configuration>";
-            Assert.Equal(TestFilesystemUtility.FormatXmlString(result), TestFilesystemUtility.ReadConfigurationFile(Path.Combine(mockBaseDirectory, configFile)));
+            Assert.Equal(result, File.ReadAllText(Path.Combine(mockBaseDirectory, configFile)));
         }
 
         [Fact]
@@ -494,7 +494,7 @@ namespace NuGet.Configuration.Test
     <add key=""key"" value=""value"" />
   </NewSectionName>
 </configuration>";
-            Assert.Equal(TestFilesystemUtility.FormatXmlString(result), TestFilesystemUtility.ReadConfigurationFile(Path.Combine(mockBaseDirectory, nugetConfigPath)));
+            Assert.Equal(result, File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)));
         }
 
         [Fact]
@@ -524,7 +524,7 @@ namespace NuGet.Configuration.Test
     <add key=""keyTwo"" value=""valueTwo"" />
   </SectionName>
 </configuration>";
-            Assert.Equal(TestFilesystemUtility.FormatXmlString(result), TestFilesystemUtility.ReadConfigurationFile(Path.Combine(mockBaseDirectory, nugetConfigPath)));
+            Assert.Equal(result, File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)));
         }
 
         [Fact]
@@ -554,7 +554,7 @@ namespace NuGet.Configuration.Test
     <add key=""key"" value=""NewValue"" />
   </SectionName>
 </configuration>";
-            Assert.Equal(TestFilesystemUtility.FormatXmlString(result), TestFilesystemUtility.ReadConfigurationFile(Path.Combine(mockBaseDirectory, nugetConfigPath)));
+            Assert.Equal(result, File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)));
         }
 
         [Fact]
@@ -590,7 +590,7 @@ namespace NuGet.Configuration.Test
     <add key=""key2"" value=""Value2"" />
   </SectionName>
 </configuration>";
-            Assert.Equal(TestFilesystemUtility.FormatXmlString(result), TestFilesystemUtility.ReadConfigurationFile(Path.Combine(mockBaseDirectory, nugetConfigPath)));
+            Assert.Equal(result, File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)));
         }
 
         [Fact]
@@ -623,7 +623,7 @@ namespace NuGet.Configuration.Test
     </MyKey>
   </SectionName>
 </configuration>";
-            Assert.Equal(TestFilesystemUtility.FormatXmlString(result), TestFilesystemUtility.ReadConfigurationFile(Path.Combine(mockBaseDirectory, nugetConfigPath)));
+            Assert.Equal(result, File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)));
         }
 
         [Fact]
@@ -666,7 +666,7 @@ namespace NuGet.Configuration.Test
     </MyKey2>
   </SectionName>
 </configuration>";
-            Assert.Equal(TestFilesystemUtility.FormatXmlString(result), TestFilesystemUtility.ReadConfigurationFile(Path.Combine(mockBaseDirectory, nugetConfigPath)));
+            Assert.Equal(result, File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)));
         }
 
         [Fact]
@@ -707,7 +707,7 @@ namespace NuGet.Configuration.Test
     </MyKey>
   </SectionName>
 </configuration>";
-            Assert.Equal(TestFilesystemUtility.FormatXmlString(result), TestFilesystemUtility.ReadConfigurationFile(Path.Combine(mockBaseDirectory, nugetConfigPath)));
+            Assert.Equal(result, File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)));
         }
 
         [Fact]
@@ -808,7 +808,7 @@ namespace NuGet.Configuration.Test
     <add key=""key"" value=""value"" />
   </SectionName2>
 </configuration>";
-            Assert.Equal(TestFilesystemUtility.FormatXmlString(result), TestFilesystemUtility.ReadConfigurationFile(Path.Combine(mockBaseDirectory, nugetConfigPath)));
+            Assert.Equal(result, File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)));
         }
 
         [Fact]
@@ -872,7 +872,7 @@ namespace NuGet.Configuration.Test
     <add key=""key"" value=""value"" />
   </SectionName2>
 </configuration>";
-            Assert.Equal(TestFilesystemUtility.FormatXmlString(result), TestFilesystemUtility.ReadConfigurationFile(Path.Combine(mockBaseDirectory, nugetConfigPath)));
+            Assert.Equal(result, File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)));
         }
 
         [Fact]
@@ -894,7 +894,7 @@ namespace NuGet.Configuration.Test
             SettingsUtility.SetEncryptedValue(settings, "SectionName", "key", "NewValue");
 
             // Assert
-            var content = TestFilesystemUtility.ReadConfigurationFile(Path.Combine(mockBaseDirectory, nugetConfigPath));
+            var content = File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath));
             Assert.False(content.Contains("NewValue"));
         }
 
@@ -1675,7 +1675,7 @@ namespace NuGet.Configuration.Test
             settings.SetValue("SectionName", "key1", "newValue");
 
             // Assert
-            var text = TestFilesystemUtility.ReadConfigurationFile(Path.Combine(mockBaseDirectory, "user.config"));
+            var text = File.ReadAllText(Path.Combine(mockBaseDirectory, "user.config"));
             var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <SectionName>
@@ -1683,13 +1683,13 @@ namespace NuGet.Configuration.Test
     <add key=""key1"" value=""newValue"" />
   </SectionName>
 </configuration>";
-            Assert.Equal(TestFilesystemUtility.FormatXmlString(result), text);
+            Assert.Equal(result, text);
 
-            text = TestFilesystemUtility.ReadConfigurationFile(Path.Combine(mockBaseDirectory, @"NuGet\Config\a1.config"));
-            Assert.Equal(TestFilesystemUtility.FormatXmlString(a1Config), text);
+            text = File.ReadAllText(Path.Combine(mockBaseDirectory, @"NuGet\Config\a1.config"));
+            Assert.Equal(a1Config, text);
 
-            text = TestFilesystemUtility.ReadConfigurationFile(Path.Combine(mockBaseDirectory, @"NuGet\Config\IDE\a2.config"));
-            Assert.Equal(TestFilesystemUtility.FormatXmlString(a2Config), text);
+            text = File.ReadAllText(Path.Combine(mockBaseDirectory, @"NuGet\Config\IDE\a2.config"));
+            Assert.Equal(a2Config, text);
         }
 
         // Tests that when configFileName is not null, the specified

--- a/test/NuGet.Configuration.Test/TestUtils.cs
+++ b/test/NuGet.Configuration.Test/TestUtils.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Xml.Linq;
 
 namespace NuGet.Configuration.Test
 {
@@ -45,23 +44,6 @@ namespace NuGet.Configuration.Test
                 var info = new UTF8Encoding(true).GetBytes(configurationContent);
                 file.Write(info, 0, info.Count());
             }
-        }
-
-        public static string ReadConfigurationFile(string path)
-        {
-            using (var fs = File.OpenRead(path))
-            {
-                using (var streamReader = new StreamReader(fs))
-                {
-                    return FormatXmlString(streamReader.ReadToEnd());
-                }
-            }
-        }
-
-        // this method is for formating xml string
-        public static string FormatXmlString(string result)
-        {
-            return XDocument.Parse(result).ToString();
         }
     }
 }


### PR DESCRIPTION
…pears prior to clear elements
