### PR TITLE
Avoid writing out the lock file for noop restores

### DIFF
--- a/src/NuGet.Commands/RestoreCommand.cs
+++ b/src/NuGet.Commands/RestoreCommand.cs
@@ -109,7 +109,15 @@ namespace NuGet.Commands
             // Generate Targets/Props files
             var msbuild = RestoreMSBuildFiles(_request.Project, graphs, localRepository, context);
 
-            return new RestoreResult(_success, graphs, checkResults, lockFile, projectLockFilePath, relockFile, msbuild);
+            return new RestoreResult(
+                _success,
+                graphs,
+                checkResults,
+                lockFile,
+                _request.ExistingLockFile,
+                projectLockFilePath,
+                relockFile,
+                msbuild);
         }
 
         private async Task<IEnumerable<RestoreTargetGraph>> ExecuteRestoreAsync(NuGetv3LocalRepository localRepository,
@@ -198,7 +206,7 @@ namespace NuGet.Commands
             allGraphs.AddRange(result.Item2);
 
             _success = success;
-            
+
             // Calculate compatibility profiles to check by merging those defined in the project with any from the command line
             foreach (var profile in _request.Project.RuntimeGraph.Supports)
             {

--- a/src/NuGet.ProjectModel/LockFileItem.cs
+++ b/src/NuGet.ProjectModel/LockFileItem.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NuGet.ProjectModel
 {
-    public class LockFileItem
+    public class LockFileItem : IEquatable<LockFileItem>
     {
         public LockFileItem(string path)
         {
@@ -17,5 +19,45 @@ namespace NuGet.ProjectModel
         public IDictionary<string, string> Properties { get; } = new Dictionary<string, string>();
 
         public override string ToString() => Path;
+
+        public bool Equals(LockFileItem other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (Object.ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            if (string.Equals(Path, other.Path, StringComparison.OrdinalIgnoreCase))
+            {
+                return Properties.OrderBy(pair => pair.Key)
+                    .SequenceEqual(other.Properties.OrderBy(pair => pair.Key));
+            }
+
+            return false;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as LockFileItem);
+        }
+
+        public override int GetHashCode()
+        {
+            var combiner = new HashCodeCombiner();
+
+            combiner.AddStringIgnoreCase(Path);
+
+            foreach (var pair in Properties.OrderBy(pair => pair.Key))
+            {
+                combiner.AddObject(pair);
+            }
+
+            return combiner.CombinedHash;
+        }
     }
 }

--- a/src/NuGet.ProjectModel/LockFileLibrary.cs
+++ b/src/NuGet.ProjectModel/LockFileLibrary.cs
@@ -1,12 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using NuGet.Versioning;
 
 namespace NuGet.ProjectModel
 {
-    public class LockFileLibrary
+    public class LockFileLibrary : IEquatable<LockFileLibrary>
     {
         public string Name { get; set; }
 
@@ -19,5 +21,53 @@ namespace NuGet.ProjectModel
         public string Sha512 { get; set; }
 
         public IList<string> Files { get; set; } = new List<string>();
+
+        public bool Equals(LockFileLibrary other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (Object.ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            if (string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(Type, other.Type, StringComparison.OrdinalIgnoreCase)
+                && IsServiceable == other.IsServiceable
+                && Sha512 == other.Sha512
+                && Version == other.Version)
+            {
+                return Files.OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+                    .SequenceEqual(other.Files.OrderBy(s => s, StringComparer.OrdinalIgnoreCase));
+            }
+
+            return false;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as LockFileLibrary);
+        }
+
+        public override int GetHashCode()
+        {
+            var combiner = new HashCodeCombiner();
+
+            combiner.AddStringIgnoreCase(Name);
+            combiner.AddStringIgnoreCase(Type);
+            combiner.AddObject(Sha512);
+            combiner.AddObject(IsServiceable);
+            combiner.AddObject(Version);
+
+            foreach (var file in Files.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
+            {
+                combiner.AddStringIgnoreCase(file);
+            }
+
+            return combiner.CombinedHash;
+        }
     }
 }

--- a/src/NuGet.ProjectModel/LockFileTarget.cs
+++ b/src/NuGet.ProjectModel/LockFileTarget.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using NuGet.Frameworks;
 
 namespace NuGet.ProjectModel
 {
-    public class LockFileTarget
+    public class LockFileTarget : IEquatable<LockFileTarget>
     {
         public NuGetFramework TargetFramework { get; set; }
 
@@ -15,5 +17,49 @@ namespace NuGet.ProjectModel
         public string Name => TargetFramework + (string.IsNullOrEmpty(RuntimeIdentifier) ? "" : "/" + RuntimeIdentifier);
 
         public IList<LockFileTargetLibrary> Libraries { get; set; } = new List<LockFileTargetLibrary>();
+
+        public bool Equals(LockFileTarget other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (Object.ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            if (NuGetFramework.Comparer.Equals(TargetFramework, other.TargetFramework)
+                && string.Equals(RuntimeIdentifier, other.RuntimeIdentifier)
+                && string.Equals(Name, other.Name))
+            {
+                return Libraries.OrderBy(library => library.Name, StringComparer.OrdinalIgnoreCase)
+                    .SequenceEqual(other.Libraries.OrderBy(library => library.Name, StringComparer.OrdinalIgnoreCase));
+            }
+
+            return false;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as LockFileTarget);
+        }
+
+        public override int GetHashCode()
+        {
+            var combiner = new HashCodeCombiner();
+
+            combiner.AddObject(TargetFramework);
+            combiner.AddObject(RuntimeIdentifier);
+            combiner.AddObject(Name);
+
+            foreach (var library in Libraries.OrderBy(library => library.Name, StringComparer.OrdinalIgnoreCase))
+            {
+                combiner.AddObject(library);
+            }
+
+            return combiner.CombinedHash;
+        }
     }
 }

--- a/src/NuGet.ProjectModel/LockFileTargetLibrary.cs
+++ b/src/NuGet.ProjectModel/LockFileTargetLibrary.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 
 namespace NuGet.ProjectModel
 {
-    public class LockFileTargetLibrary
+    public class LockFileTargetLibrary : IEquatable<LockFileTargetLibrary>
     {
         public string Name { get; set; }
 
@@ -24,5 +26,78 @@ namespace NuGet.ProjectModel
         public IList<LockFileItem> CompileTimeAssemblies { get; set; } = new List<LockFileItem>();
 
         public IList<LockFileItem> NativeLibraries { get; set; } = new List<LockFileItem>();
+
+        public bool Equals(LockFileTargetLibrary other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (Object.ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return string.Equals(Name, other.Name)
+                && VersionComparer.Default.Equals(Version, other.Version)
+                && Dependencies.OrderBy(dependency => dependency.Id, StringComparer.OrdinalIgnoreCase)
+                    .SequenceEqual(other.Dependencies.OrderBy(dependency => dependency.Id, StringComparer.OrdinalIgnoreCase))
+                && FrameworkAssemblies.OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+                    .SequenceEqual(other.FrameworkAssemblies.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
+                && RuntimeAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase)
+                    .SequenceEqual(other.RuntimeAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
+                && ResourceAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase)
+                    .SequenceEqual(other.ResourceAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
+                && CompileTimeAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase)
+                    .SequenceEqual(other.CompileTimeAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
+                && NativeLibraries.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase)
+                    .SequenceEqual(other.NativeLibraries.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase));
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as LockFileTargetLibrary);
+        }
+
+        public override int GetHashCode()
+        {
+            var combiner = new HashCodeCombiner();
+
+            combiner.AddObject(Name);
+            combiner.AddObject(Version);
+
+            foreach (var dependency in Dependencies.OrderBy(dependency => dependency.Id, StringComparer.OrdinalIgnoreCase))
+            {
+                combiner.AddObject(dependency);
+            }
+
+            foreach (var reference in FrameworkAssemblies.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
+            {
+                combiner.AddStringIgnoreCase(reference);
+            }
+
+            foreach (var item in RuntimeAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
+            {
+                combiner.AddObject(item);
+            }
+
+            foreach (var item in ResourceAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
+            {
+                combiner.AddObject(item);
+            }
+
+            foreach (var item in CompileTimeAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
+            {
+                combiner.AddObject(item);
+            }
+
+            foreach (var item in NativeLibraries.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
+            {
+                combiner.AddObject(item);
+            }
+
+            return combiner.CombinedHash;
+        }
     }
 }

--- a/src/NuGet.ProjectModel/ProjectFileDependencyGroup.cs
+++ b/src/NuGet.ProjectModel/ProjectFileDependencyGroup.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.LibraryModel;
 
 namespace NuGet.ProjectModel
 {
-    public class ProjectFileDependencyGroup
+    public class ProjectFileDependencyGroup : IEquatable<ProjectFileDependencyGroup>
     {
         public ProjectFileDependencyGroup(string frameworkName, IEnumerable<string> dependencies)
         {
@@ -18,5 +19,55 @@ namespace NuGet.ProjectModel
         public string FrameworkName { get; }
 
         public IEnumerable<string> Dependencies { get; }
+
+        public bool Equals(ProjectFileDependencyGroup other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (Object.ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            if (string.Equals(FrameworkName, other.FrameworkName, StringComparison.OrdinalIgnoreCase))
+            {
+                if (Dependencies == null || other.Dependencies == null)
+                {
+                    return Dependencies == other.Dependencies;
+                }
+
+                return Dependencies.OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+                    .SequenceEqual(
+                        other.Dependencies.OrderBy(s => s, StringComparer.OrdinalIgnoreCase),
+                        StringComparer.OrdinalIgnoreCase);
+            }
+
+            return false;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ProjectFileDependencyGroup);
+        }
+
+        public override int GetHashCode()
+        {
+            var combiner = new HashCodeCombiner();
+
+            combiner.AddStringIgnoreCase(FrameworkName);
+
+            if (Dependencies != null)
+            {
+                foreach (var dependency in Dependencies.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
+                {
+                    combiner.AddStringIgnoreCase(dependency);
+                }
+            }
+
+            return combiner.CombinedHash;
+        }
     }
 }


### PR DESCRIPTION
This change allows RestoreResult.Commit(ILogger) to no-op if the lock file is identical to the existing lock file.

The majority of this change is adding Equals and GetHashCode methods to LockFile and all child types.

Fixes https://github.com/NuGet/Home/issues/844

//cc @anurse @yishaigalatzer @davidfowl @pranavkm 
