### PR TITLE
Use NET45 instead of DNX451 directive

### DIFF
--- a/src/NuGet.Protocol.Core.v3/RemoteRepositories/HttpSource.cs
+++ b/src/NuGet.Protocol.Core.v3/RemoteRepositories/HttpSource.cs
@@ -175,7 +175,7 @@ retryWithAuthentication:
             var baseFolderName = RemoveInvalidFileNameChars(ComputeHash(_baseUri.OriginalString));
             var baseFileName = RemoveInvalidFileNameChars(cacheKey) + ".dat";
 
-#if DNX451
+#if NET45
             var localAppDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 #else
             var localAppDataFolder = Environment.GetEnvironmentVariable("LocalAppData");


### PR DESCRIPTION
- NuGet.Protocol.Core.v3 is built for net45 not dnx451, so the code path was always looking for the Environment variable instead of the SpecialFolder.
