### PR TITLE
fixed https://github.com/NuGet/Home/issues/998

### DIFF
--- a/src/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Configuration/Settings/Settings.cs
@@ -138,9 +138,9 @@ namespace NuGet.Configuration
                     validSettingFiles.AddRange(
                         GetSettingsFileNames(root)
                             .Select(f => ReadSettings(root, f))
-                            .Where(f => f != null));
+                            .Where(f => f != null && !f.ConfigFilePath.Equals(Path.GetFullPath(Path.Combine(root, configFileName??"")))));
                 }
-
+               
                 if (loadAppDataSettings)
                 {
                     LoadUserSpecificSettings(validSettingFiles, root, configFileName, machineWideSettings);


### PR DESCRIPTION
the root casue of this bug is settings loaded same config file twice.
when user use nuget.exe sources add command to add source to local config file by using -ConfigFile,
and if config file name is NuGet.config, loadAppDataConfig and hierarchy Config search will add same config file to settings twice.(also exist in 2.8.6)
in this case, when we add a new source to the config file, for first setting, it will add source and save, for second setting, no new source and save. becasue they are same config file, so the second one overwrite the first one.

the fix is never add user speficific config to settings during hierarchy config search.
