### PR TITLE
add origin data to PackageSource to aid in diagnostics

### DIFF
--- a/src/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -58,6 +58,11 @@ namespace NuGet.Configuration
             }
         }
 
+        /// <summary>
+        /// Gets the <see cref="ISettings"/> that this source originated from. May be null.
+        /// </summary>
+        public ISettings Origin { get; set; }
+
         public PackageSource(string source)
             :
                 this(source, source, isEnabled: true)

--- a/src/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -189,15 +189,17 @@ namespace NuGet.Configuration
             var v3Setting = new SettingValue(
                 NuGetConstants.FeedName,
                 NuGetConstants.V3FeedUrl,
+                origin: settings,
                 isMachineWide: false,
                 priority: 1);
             v3Setting.AdditionalData[ConfigurationContants.ProtocolVersionAttribute] = "3";
 
             var v2Setting = new SettingValue(
-               NuGetConstants.FeedName,
-               NuGetConstants.V2FeedUrl,
-               isMachineWide: false,
-               priority: 1);
+                NuGetConstants.FeedName,
+                NuGetConstants.V2FeedUrl,
+                origin: settings,
+                isMachineWide: false,
+                priority: 1);
 
             if (settingToMigrate.Length == 0)
             {
@@ -246,6 +248,7 @@ namespace NuGet.Configuration
             }
 
             packageSource.ProtocolVersion = ReadProtocolVersion(setting);
+            packageSource.Origin = setting.Origin;
 
             return packageSource;
         }
@@ -548,7 +551,8 @@ namespace NuGet.Configuration
                     // This is a new source, add it to the Setting with the lowest priority.
                     // if there is a clear tag in one config file, new source will be cleared
                     // we should set new source priority to lowest existingSetting priority
-                    var settingValue = new SettingValue(source.Name, source.Source, isMachineWide: false, priority: minPriority);
+                    // NOTE: origin can be null here because it isn't ever used when saving.
+                    var settingValue = new SettingValue(source.Name, source.Source, origin: null, isMachineWide: false, priority: minPriority);
 
                     if (source.ProtocolVersion != PackageSource.DefaultProtocolVersion)
                     {
@@ -571,14 +575,14 @@ namespace NuGet.Configuration
                 if (!source.IsEnabled)
                 {
                     // Add an entry to the disabledPackageSource in the file that contains
-                    sourcesToDisable.Add(new SettingValue(source.Name, "true", isMachineWide: false, priority: settingPriority));
+                    sourcesToDisable.Add(new SettingValue(source.Name, "true", origin: null, isMachineWide: false, priority: settingPriority));
                 }
             }
 
             // add entries to the disabledPackageSource for machine wide setting
             foreach (var source in sources.Where(s => s.IsMachineWide && !s.IsEnabled))
             {
-                sourcesToDisable.Add(new SettingValue(source.Name, "true", isMachineWide: true, priority: 0));
+                sourcesToDisable.Add(new SettingValue(source.Name, "true", origin: null, isMachineWide: true, priority: 0));
             }
 
             // Write the updates to the nearest settings file.

--- a/src/NuGet.Configuration/Settings/SettingValue.cs
+++ b/src/NuGet.Configuration/Settings/SettingValue.cs
@@ -13,9 +13,14 @@ namespace NuGet.Configuration
     public class SettingValue
     {
         public SettingValue(string key, string value, bool isMachineWide, int priority = 0)
+            : this(key, value, origin: null, isMachineWide: isMachineWide, priority: priority)
+        { }
+
+        public SettingValue(string key, string value, ISettings origin, bool isMachineWide, int priority = 0)
         {
             Key = key;
             Value = value;
+            Origin = origin;
             IsMachineWide = isMachineWide;
             Priority = priority;
             AdditionalData = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -40,6 +45,11 @@ namespace NuGet.Configuration
         /// The priority of this setting in the nuget.config hierarchy. Bigger number means higher priority
         /// </summary>
         public int Priority { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="ISettings"/> that provided this value.
+        /// </summary>
+        public ISettings Origin { get; }
 
         /// <summary>
         /// Gets additional values with the specified setting.

--- a/src/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Configuration/Settings/Settings.cs
@@ -225,7 +225,7 @@ namespace NuGet.Configuration
                             var values = setting.GetSettingValues(ConfigurationContants.PackageSources, isPath: true);
                             foreach (var value in values)
                             {
-                                disabledSources.Add(new SettingValue(value.Key, "true", isMachineWide: true, priority: 0));
+                                disabledSources.Add(new SettingValue(value.Key, "true", origin: setting, isMachineWide: true, priority: 0));
                             }
                         }
                         appDataSettings.UpdateSections(ConfigurationContants.DisabledPackageSources, disabledSources);
@@ -808,7 +808,7 @@ namespace NuGet.Configuration
                 value = Path.Combine(Root, Path.Combine(configDirectory, value));
             }
 
-            var settingValue = new SettingValue(keyAttribute.Value, value, IsMachineWideSettings, _priority);
+            var settingValue = new SettingValue(keyAttribute.Value, value, origin: this, isMachineWide: IsMachineWideSettings, priority: _priority);
             foreach (var attribute in element.Attributes())
             {
                 // Add all attributes other than ConfigurationContants.KeyAttribute and ConfigurationContants.ValueAttribute to AdditionalValues


### PR DESCRIPTION
It looks like we're going to try to integrate NuGet.Configuration in to DNU! As a result, it would be really useful to pull in some of the tweaks we've made to our forked code.

This is used to provide the `dnu feeds list` command with the path to the Config file that caused a Source to be added to the set. As a result, we can provide output like this:

![screenshot](https://cloud.githubusercontent.com/assets/7574/8607489/08cbb60c-2648-11e5-802d-16d155a73485.png)

The idea here is just to track the `ISettings` that created a `SettingsValue` and pass that along to the `PackageSource` when it is created. As a result, we end up being able to try-cast that back down to the concrete `Settings` class and get the path to the NuGet.config file that last affected the source.

See https://github.com/aspnet/dnx/pull/2234 for example of how this is used.

/cc @emgarten @deepakaravindr @pranavkm @yishaigalatzer 
