### PR TITLE
Fix null reference exception from dependency conflict checks

### DIFF
--- a/src/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -260,6 +260,7 @@ namespace NuGet.DependencyResolver
                     if (acceptedLibraries.TryGetValue(childNode.Key.Name, out acceptedNode) &&
                         childNode != acceptedNode &&
                         childNode.Key.VersionRange != null &&
+                        string.Equals(childNode.Key.TypeConstraint, acceptedNode.Key.TypeConstraint, StringComparison.Ordinal) &&
                         !childNode.Key.VersionRange.Satisfies(acceptedNode.Item.Key.Version))
                     {
                         versionConflicts.Add(new VersionConflictResult<TItem>

--- a/test/NuGet.Commands.Test/UWPRestoreTests.cs
+++ b/test/NuGet.Commands.Test/UWPRestoreTests.cs
@@ -1,0 +1,189 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class UWPRestoreTests
+    {
+        private ConcurrentBag<string> _testFolders = new ConcurrentBag<string>();
+
+        // Verify that File > New Project > Blank UWP App can restore without errors or warnings.
+        [Fact]
+        public async Task UWPRestore_BlankUWPApp()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+            sources.Add(new PackageSource("https://api.nuget.org/v3/index.json"));
+            var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
+            var projectDir = TestFileSystemUtility.CreateRandomTestFolder();
+            _testFolders.Add(packagesDir);
+            _testFolders.Add(projectDir);
+
+            var configJson = JObject.Parse(@"{
+                  ""dependencies"": {
+                    ""Microsoft.NETCore.UniversalWindowsPlatform"": ""5.0.0""
+                  },
+                  ""frameworks"": {
+                    ""uap10.0"": {}
+                  },
+                  ""runtimes"": {
+                    ""win10-arm"": {},
+                    ""win10-arm-aot"": {},
+                    ""win10-x86"": {},
+                    ""win10-x86-aot"": {},
+                    ""win10-x64"": {},
+                    ""win10-x64-aot"": {}
+                  }
+                }");
+
+            var specPath = Path.Combine(projectDir, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+
+            var request = new RestoreRequest(spec, sources, packagesDir);
+            request.MaxDegreeOfConcurrency = 2;
+            request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
+
+            var lockFileFormat = new LockFileFormat();
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger, request);
+
+            // Act
+            var result = await command.ExecuteAsync();
+            result.Commit(logger);
+
+            // Assert
+            Assert.Equal(0, result.CompatibilityCheckResults.Sum(checkResult => checkResult.Issues.Count));
+            Assert.Equal(0, logger.Errors);
+            Assert.Equal(0, logger.Warnings);
+            Assert.Equal(118, result.GetAllInstalled().Count);
+        }
+
+        // Verify that File > New Project > Class Library (Portable) can restore without errors or warnings.
+        [Fact]
+        public async Task UWPRestore_ModernPCL()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+            sources.Add(new PackageSource("https://api.nuget.org/v3/index.json"));
+            var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
+            var projectDir = TestFileSystemUtility.CreateRandomTestFolder();
+            _testFolders.Add(packagesDir);
+            _testFolders.Add(projectDir);
+
+            var configJson = JObject.Parse(@"{
+                  ""supports"": {
+                    ""net46.app"": { },
+                    ""uwp.10.0.app"": { },
+                    ""dnxcore50.app"": { }
+                        },
+                  ""dependencies"": {
+                    ""Microsoft.NETCore"": ""5.0.0"",
+                    ""Microsoft.NETCore.Portable.Compatibility"": ""1.0.0""
+                  },
+                  ""frameworks"": {
+                    ""dotnet"": {
+                      ""imports"": ""portable-net452+win81""
+                    }
+                  }
+                }");
+
+            var specPath = Path.Combine(projectDir, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+
+            var request = new RestoreRequest(spec, sources, packagesDir);
+            request.MaxDegreeOfConcurrency = 2;
+            request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
+
+            var lockFileFormat = new LockFileFormat();
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger, request);
+
+            // Act
+            var result = await command.ExecuteAsync();
+            result.Commit(logger);
+
+            // Assert
+            Assert.Equal(0, result.CompatibilityCheckResults.Sum(checkResult => checkResult.Issues.Count));
+            Assert.Equal(0, logger.Errors);
+            Assert.Equal(0, logger.Warnings);
+            Assert.Equal(86, result.GetAllInstalled().Count);
+        }
+
+        // Verify that installing all Office 365 services into a UWP app restores without errors.
+        [Fact]
+        public async Task UWPRestore_UWPAppWithOffice365Packages()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+            sources.Add(new PackageSource("https://api.nuget.org/v3/index.json"));
+            var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
+            var projectDir = TestFileSystemUtility.CreateRandomTestFolder();
+            _testFolders.Add(packagesDir);
+            _testFolders.Add(projectDir);
+
+            var configJson = JObject.Parse(@"{
+                  ""dependencies"": {
+                    ""Microsoft.ApplicationInsights"": ""1.0.0"",
+                    ""Microsoft.ApplicationInsights.PersistenceChannel"": ""1.0.0"",
+                    ""Microsoft.ApplicationInsights.WindowsApps"": ""1.0.0"",
+                    ""Microsoft.Azure.ActiveDirectory.GraphClient"": ""2.0.6"",
+                    ""Microsoft.IdentityModel.Clients.ActiveDirectory"": ""2.14.201151115"",
+                    ""Microsoft.NETCore.UniversalWindowsPlatform"": ""5.0.0"",
+                    ""Microsoft.Office365.Discovery"": ""1.0.22"",
+                    ""Microsoft.Office365.OutlookServices"": ""1.0.35"",
+                    ""Microsoft.Office365.SharePoint"": ""1.0.22""
+                  },
+                  ""frameworks"": {
+                    ""uap10.0"": {}
+                  },
+                  ""runtimes"": {
+                    ""win10-arm"": {},
+                    ""win10-arm-aot"": {},
+                    ""win10-x86"": {},
+                    ""win10-x86-aot"": {},
+                    ""win10-x64"": {},
+                    ""win10-x64-aot"": {}
+                  }
+                }");
+
+            var specPath = Path.Combine(projectDir, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+
+            var request = new RestoreRequest(spec, sources, packagesDir);
+            request.MaxDegreeOfConcurrency = 2;
+            request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
+
+            var lockFileFormat = new LockFileFormat();
+            var logger = new TestLogger();
+            var command = new RestoreCommand(logger, request);
+
+            // Act
+            var result = await command.ExecuteAsync();
+            result.Commit(logger);
+
+            // Assert
+            Assert.Equal(0, result.CompatibilityCheckResults.Sum(checkResult => checkResult.Issues.Count));
+            Assert.Equal(0, logger.Errors);
+            Assert.Equal(0, logger.Warnings);
+            Assert.Equal(140, result.GetAllInstalled().Count);
+        }
+
+        public void Dispose()
+        {
+            // Clean up
+            foreach (var folder in _testFolders)
+            {
+                TestFileSystemUtility.DeleteRandomTestFolders(folder);
+            }
+        }
+    }
+}


### PR DESCRIPTION
During the graph walk a node may be a framework reference which does not contain a version. When checking for conflicts this throws a null ref. The fix for this is to filter based on type constraints to avoid these references.

https://github.com/NuGet/Home/issues/1116

//cc @pranavkm @yishaigalatzer @deepakaravindr 
