### PR TITLE
Don't wait for 401 - include authorization header if basic credential…

### DIFF
--- a/src/NuGet.Protocol.Core.v3/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Protocol.Core.v3/HttpHandlerResourceV3Provider.cs
@@ -75,7 +75,7 @@ namespace NuGet.Protocol.Core.v3
                 CredentialStore.Instance.Add(uri, credential);
             }
 
-            return new CredentialPromptWebRequestHandler()
+            return new CredentialPromptWebRequestHandler(uri)
             {
                 Proxy = proxy,
                 Credentials = credential
@@ -84,12 +84,21 @@ namespace NuGet.Protocol.Core.v3
 
         private class CredentialPromptWebRequestHandler : WebRequestHandler
         {
+            private Uri _serviceIndexUri;
+
+            public CredentialPromptWebRequestHandler(Uri serviceIndexUri)
+            {
+                _serviceIndexUri = serviceIndexUri;
+            }
+
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 while (true)
                 {
                     try
                     {
+                        AddBasicAuthorizationHeaderIfAvailable(request);
+
                         var response = await base.SendAsync(request, cancellationToken);
                         if (HttpHandlerResourceV3.ProxyPassed != null && Proxy != null)
                         {
@@ -117,6 +126,33 @@ namespace NuGet.Protocol.Core.v3
                         {
                             throw;
                         }
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Adds an explicit Authorization header to the request, if basic auth credentials for the package source
+            /// are available, no authorization header already exists on the request, and the request is for the
+            /// same scheme and authority as the service index.
+            /// </summary>
+            /// <remarks>
+            /// Resolves https://github.com/NuGet/Home/issues/742: NuGet should set PreAuthenticate to true to reduce the number of web requests
+            /// Note that PreAuthenticate doesn't do what you'd expect (it still doesn't use creds on the very first request),
+            /// so we set Authorization manually.
+            /// </remarks>
+            private void AddBasicAuthorizationHeaderIfAvailable(HttpRequestMessage request)
+            {
+                if (this.Credentials != null &&
+                    Uri.Compare(request.RequestUri, _serviceIndexUri, UriComponents.SchemeAndServer, UriFormat.Unescaped, StringComparison.InvariantCultureIgnoreCase) == 0 &&
+                    !request.Headers.Contains("Authorization"))
+                {
+                    NetworkCredential basicCred = this.Credentials.GetCredential(_serviceIndexUri, "Basic");
+
+                    if (basicCred != null)
+                    {
+                        byte[] rawUserAndPass = System.Text.Encoding.UTF8.GetBytes(String.Format("{0}:{1}", basicCred.UserName, basicCred.Password));
+                        string authValueEncoded = Convert.ToBase64String(rawUserAndPass);
+                        request.Headers.Add("Authorization", String.Format("Basic {0}", authValueEncoded));
                     }
                 }
             }


### PR DESCRIPTION
Resolves NuGet/Home#742 by always including Authorization header if basic credentials exist and the request is for the same server.
