### PR TITLE
Setting the targetPath which is the fullPath to files added instead o…

### DIFF
--- a/src/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Packaging/PackageExtractor.cs
@@ -131,7 +131,7 @@ namespace NuGet.Packaging
                         }
                     }
 
-                    filesAdded.Add(file);
+                    filesAdded.Add(targetPath);
                 }
             }
 


### PR DESCRIPTION
…f zipArchiveEntry's fullname. Related to https://github.com/NuGet/Home/issues/980

@yishaigalatzer @emgarten 
