### PR TITLE
Retry on 5xx status codes

### DIFF
--- a/src/NuGet.Protocol.Core.Types/Resources/HttpHandlerResource.cs
+++ b/src/NuGet.Protocol.Core.Types/Resources/HttpHandlerResource.cs
@@ -11,8 +11,13 @@ namespace NuGet.Protocol.Core.Types
     public abstract class HttpHandlerResource : INuGetResource
     {
         /// <summary>
-        /// HttpClient resource
+        /// HttpClientHandler used for credential support.
         /// </summary>
-        public abstract HttpClientHandler MessageHandler { get; }
+        public abstract HttpClientHandler ClientHandler { get; }
+
+        /// <summary>
+        /// Message handler containing the ClientHandler.
+        /// </summary>
+        public abstract HttpMessageHandler MessageHandler { get; }
     }
 }

--- a/src/NuGet.Protocol.Core.v3/DataClient/RetryHandler.cs
+++ b/src/NuGet.Protocol.Core.v3/DataClient/RetryHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,15 +10,19 @@ namespace NuGet.Protocol.Core.v3.Data
 {
     public class RetryHandler : DelegatingHandler
     {
-        private readonly int _retries;
+        /// <summary>
+        /// Total number of requests allowed for a single call.
+        /// </summary>
+        public int MaxTries { get; }
+        public TimeSpan RetryDelay { get; }
 
-        public RetryHandler(HttpMessageHandler innerHandler, int retries)
+        public RetryHandler(HttpMessageHandler innerHandler, int maxTries)
             : base(innerHandler)
         {
-            _retries = retries;
+            MaxTries = maxTries;
+            RetryDelay = TimeSpan.FromMilliseconds(200);
         }
 
-        // TODO: Revist this logic
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var tries = 0;
@@ -26,28 +31,37 @@ namespace NuGet.Protocol.Core.v3.Data
 
             var success = false;
 
-            while (tries < _retries
+            while (tries < MaxTries
                    && !success)
             {
-                // wait progressively longer
+                // wait before trying again if the last call failed
                 if (!success
                     && tries > 0)
                 {
-                    await Task.Delay(500 * tries, cancellationToken);
+                    await Task.Delay(200, cancellationToken);
                 }
 
                 tries++;
+                success = true;
 
                 try
                 {
                     response = await base.SendAsync(request, cancellationToken);
 
-                    success = response.IsSuccessStatusCode;
+                    var statusCode = (int)response.StatusCode;
+
+                    // fail on 5xx responses
+                    if (statusCode >= 500)
+                    {
+                        success = false;
+                    }
                 }
                 catch
                 {
+                    success = false;
+
                     // suppress exceptions until the final try
-                    if (tries >= _retries)
+                    if (tries >= MaxTries)
                     {
                         throw;
                     }

--- a/src/NuGet.Protocol.Core.v3/DependencyInfoResourceV3Provider.cs
+++ b/src/NuGet.Protocol.Core.v3/DependencyInfoResourceV3Provider.cs
@@ -27,7 +27,7 @@ namespace NuGet.Protocol.Core.v3
             {
                 var messageHandlerResource = await source.GetResourceAsync<HttpHandlerResource>(token);
 
-                var client = new DataClient(messageHandlerResource.MessageHandler);
+                var client = new DataClient(messageHandlerResource);
 
                 var regResource = await source.GetResourceAsync<RegistrationResourceV3>(token);
 

--- a/src/NuGet.Protocol.Core.v3/DownloadResourceV3Provider.cs
+++ b/src/NuGet.Protocol.Core.v3/DownloadResourceV3Provider.cs
@@ -35,7 +35,7 @@ namespace NuGet.Protocol.Core.v3
 
                     var messageHandlerResource = await source.GetResourceAsync<HttpHandlerResource>(token);
 
-                    var client = new DataClient(messageHandlerResource.MessageHandler);
+                    var client = new DataClient(messageHandlerResource);
 
                     curResource = new DownloadResourceV3(client, registrationResource);
 

--- a/src/NuGet.Protocol.Core.v3/HttpHandlerResourceV3.cs
+++ b/src/NuGet.Protocol.Core.v3/HttpHandlerResourceV3.cs
@@ -13,19 +13,31 @@ namespace NuGet.Protocol.Core.v3
     /// </summary>
     public class HttpHandlerResourceV3 : HttpHandlerResource
     {
-        private readonly HttpClientHandler _messageHandler;
+        private readonly HttpClientHandler _clientHandler;
+        private readonly HttpMessageHandler _messageHandler;
 
-        public HttpHandlerResourceV3(HttpClientHandler messageHandler)
+        public HttpHandlerResourceV3(HttpClientHandler clientHandler, HttpMessageHandler messageHandler)
         {
-            if (messageHandler == null)
+            if (clientHandler == null)
             {
-                throw new ArgumentNullException("messageHandler");
+                throw new ArgumentNullException(nameof(clientHandler));
             }
 
+            if (messageHandler == null)
+            {
+                throw new ArgumentNullException(nameof(messageHandler));
+            }
+
+            _clientHandler = clientHandler;
             _messageHandler = messageHandler;
         }
 
-        public override HttpClientHandler MessageHandler
+        public override HttpClientHandler ClientHandler
+        {
+            get { return _clientHandler; }
+        }
+
+        public override HttpMessageHandler MessageHandler
         {
             get { return _messageHandler; }
         }

--- a/src/NuGet.Protocol.Core.v3/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Protocol.Core.v3/HttpHandlerResourceV3Provider.cs
@@ -27,9 +27,17 @@ namespace NuGet.Protocol.Core.v3
         {
             HttpHandlerResourceV3 curResource = null;
 
-            // Everyone gets a dataclient
-            var httpHandler = TryGetCredentialAndProxy(source.PackageSource) ?? DataClient.DefaultHandler;
-            curResource = new HttpHandlerResourceV3(httpHandler);
+            var clientHandler = TryGetCredentialAndProxy(source.PackageSource);
+
+            if (clientHandler == null)
+            {
+                curResource = DataClient.DefaultHandler;
+            }
+            else
+            {
+                // replace the handler with the proxy aware handler
+                curResource = DataClient.CreateHandler(clientHandler);
+            }
 
             return Task.FromResult(new Tuple<bool, INuGetResource>(curResource != null, curResource));
         }

--- a/src/NuGet.Protocol.Core.v3/MetadataResourceV3Provider.cs
+++ b/src/NuGet.Protocol.Core.v3/MetadataResourceV3Provider.cs
@@ -26,7 +26,7 @@ namespace NuGet.Protocol.Core.v3
             if (regResource != null)
             {
                 var messageHandlerResource = await source.GetResourceAsync<HttpHandlerResource>(token);
-                var client = new DataClient(messageHandlerResource.MessageHandler);
+                var client = new DataClient(messageHandlerResource);
 
                 curResource = new MetadataResourceV3(client, regResource);
             }

--- a/src/NuGet.Protocol.Core.v3/RegistrationResourceV3Provider.cs
+++ b/src/NuGet.Protocol.Core.v3/RegistrationResourceV3Provider.cs
@@ -30,7 +30,7 @@ namespace NuGet.Protocol.Core.v3
 
                 var messageHandlerResource = await source.GetResourceAsync<HttpHandlerResource>(token);
 
-                var client = new DataClient(messageHandlerResource.MessageHandler);
+                var client = new DataClient(messageHandlerResource);
 
                 // construct a new resource
                 regResource = new RegistrationResourceV3(client, baseUrl);

--- a/src/NuGet.Protocol.Core.v3/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
+++ b/src/NuGet.Protocol.Core.v3/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
@@ -40,7 +40,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
         private TimeSpan _cacheAgeLimitList;
         private TimeSpan _cacheAgeLimitNupkg;
 
-        public HttpFileSystemBasedFindPackageByIdResource(IReadOnlyList<Uri> baseUris, Func<Task<HttpClientHandler>> handlerFactory)
+        public HttpFileSystemBasedFindPackageByIdResource(IReadOnlyList<Uri> baseUris, Func<Task<HttpHandlerResource>> handlerFactory)
         {
             if (baseUris == null)
             {

--- a/src/NuGet.Protocol.Core.v3/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceProvider.cs
+++ b/src/NuGet.Protocol.Core.v3/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceProvider.cs
@@ -31,7 +31,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
             {
                 resource = new HttpFileSystemBasedFindPackageByIdResource(
                     packageBaseAddress, 
-                    async () => (await sourceRepository.GetResourceAsync<HttpHandlerResource>(token)).MessageHandler);
+                    async () => (await sourceRepository.GetResourceAsync<HttpHandlerResource>(token)));
             }
 
             return Tuple.Create(resource != null, resource);

--- a/src/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
+++ b/src/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
@@ -42,7 +42,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
         private TimeSpan _cacheAgeLimitList;
         private TimeSpan _cacheAgeLimitNupkg;
 
-        public RemoteV2FindPackageByIdResource(PackageSource packageSource, Func<Task<HttpClientHandler>> handlerFactory)
+        public RemoteV2FindPackageByIdResource(PackageSource packageSource, Func<Task<HttpHandlerResource>> handlerFactory)
         {
             _baseUri = packageSource.Source.EndsWith("/") ? packageSource.Source : (packageSource.Source + "/");
             _httpSource = new HttpSource(_baseUri, handlerFactory);

--- a/src/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResourceProvider.cs
+++ b/src/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResourceProvider.cs
@@ -29,7 +29,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
             {
                 resource = new RemoteV2FindPackageByIdResource(
                     sourceRepository.PackageSource, 
-                    async () => (await sourceRepository.GetResourceAsync<HttpHandlerResource>(token)).MessageHandler);
+                    async () => (await sourceRepository.GetResourceAsync<HttpHandlerResource>(token)));
             }
 
             return Task.FromResult(Tuple.Create(resource != null, resource));

--- a/src/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
+++ b/src/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
@@ -30,7 +30,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
         private TimeSpan _cacheAgeLimitList;
         private TimeSpan _cacheAgeLimitNupkg;
 
-        public RemoteV3FindPackageByIdResource(SourceRepository sourceRepository, Func<Task<HttpClientHandler>> handlerFactory)
+        public RemoteV3FindPackageByIdResource(SourceRepository sourceRepository, Func<Task<HttpHandlerResource>> handlerFactory)
         {
             SourceRepository = sourceRepository;
             _httpSource = new HttpSource(sourceRepository.PackageSource.Source, handlerFactory);

--- a/src/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV3FindPackagePackageByIdResourceProvider.cs
+++ b/src/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV3FindPackagePackageByIdResourceProvider.cs
@@ -27,7 +27,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
             {
                 resource = new RemoteV3FindPackageByIdResource(
                     sourceRepository,
-                    async () => (await sourceRepository.GetResourceAsync<HttpHandlerResource>(token)).MessageHandler);
+                    async () => (await sourceRepository.GetResourceAsync<HttpHandlerResource>(token)));
             }
 
             return Tuple.Create(resource != null, resource);

--- a/src/NuGet.Protocol.Core.v3/ServiceIndexResourceV3Provider.cs
+++ b/src/NuGet.Protocol.Core.v3/ServiceIndexResourceV3Provider.cs
@@ -58,7 +58,7 @@ namespace NuGet.Protocol.Core.v3
                 {
                     var messageHandlerResource = await source.GetResourceAsync<HttpHandlerResource>(token);
 
-                    var client = new DataClient(messageHandlerResource.MessageHandler);
+                    var client = new DataClient(messageHandlerResource);
 
                     JObject json;
 

--- a/test/NuGet.Protocol.Core.v3.Tests/NuGet.Protocol.Core.v3.Tests.xproj
+++ b/test/NuGet.Protocol.Core.v3.Tests/NuGet.Protocol.Core.v3.Tests.xproj
@@ -13,5 +13,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/NuGet.Protocol.Core.v3.Tests/RetryHandlerTests.cs
+++ b/test/NuGet.Protocol.Core.v3.Tests/RetryHandlerTests.cs
@@ -1,0 +1,203 @@
+﻿using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Core.v3.Data;
+using Xunit;
+
+namespace NuGet.Protocol.Core.v3.Tests
+{
+    public class RetryHandlerTests
+    {
+        [Fact]
+        public async Task RetryHandler_HttpHandlerResourceV3IncludesRetryHandler()
+        {
+            // Arrange
+            var repo = Repository.Factory.GetCoreV3("https://test.local/test.json");
+
+            // Act
+            var handler = await repo.GetResourceAsync<HttpHandlerResource>();
+
+            var messageHandler = handler.MessageHandler as HttpMessageHandler;
+
+            // Assert
+            Assert.True(messageHandler is RetryHandler);
+        }
+
+        [Fact]
+        public async Task RetryHandler_MessageHandlerMultipleTriesTimed()
+        {
+            // Arrange
+            Func<HttpRequestMessage, HttpResponseMessage> handler = (request) =>
+            {
+                return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+            };
+
+            var testHandler = new TestHandler(handler);
+            var retryHandler = new RetryHandler(testHandler, 5);
+
+            var httpClient = new HttpClient(retryHandler);
+
+            var minTime = GetRetryMinTime(retryHandler.MaxTries, retryHandler);
+
+            // Act
+            var timer = new Stopwatch();
+            timer.Start();
+            var response = await httpClient.GetAsync("https://test.local/test.json");
+            timer.Stop();
+
+            // Assert
+            Assert.True(timer.Elapsed >= minTime, 
+                string.Format("Expected this to take at least: {0} But it finished in: {1}",
+                    minTime,
+                    timer.Elapsed));
+        }
+
+        [Fact]
+        public async Task RetryHandler_MessageHandlerMultipleTriesNoSuccess()
+        {
+            // Arrange
+            var hits = 0;
+
+            Func<HttpRequestMessage, HttpResponseMessage> handler = (request) =>
+            {
+                hits++;
+
+                return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+            };
+
+            var testHandler = new TestHandler(handler);
+            var retryHandler = new RetryHandler(testHandler, 5);
+
+            var httpClient = new HttpClient(retryHandler);
+
+            // Act
+            var response = await httpClient.GetAsync("https://test.local/test.json");
+            var triesCount = retryHandler.MaxTries;
+
+            // Assert
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+            Assert.Equal(5, hits);
+            Assert.Equal(5, triesCount);
+        }
+
+        [Fact]
+        public async Task RetryHandler_MessageHandlerMultipleSuccessFirstVerifySingleHit()
+        {
+            // Arrange
+            var hits = 0;
+
+            Func<HttpRequestMessage, HttpResponseMessage> handler = (request) =>
+            {
+                hits++;
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            };
+
+            var testHandler = new TestHandler(handler);
+            var retryHandler = new RetryHandler(testHandler, 10);
+
+            var httpClient = new HttpClient(retryHandler);
+
+            // Act
+            var response = await httpClient.GetAsync("https://test.local/test.json");
+
+            // Assert
+            Assert.Equal(1, hits);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task RetryHandler_MessageHandler404VerifySingleHit()
+        {
+            // Arrange
+            var hits = 0;
+
+            Func<HttpRequestMessage, HttpResponseMessage> handler = (request) =>
+            {
+                hits++;
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            };
+
+            var testHandler = new TestHandler(handler);
+            var retryHandler = new RetryHandler(testHandler, 10);
+
+            var httpClient = new HttpClient(retryHandler);
+
+            // Act
+            var response = await httpClient.GetAsync("https://test.local/test.json");
+
+            // Assert
+            Assert.Equal(1, hits);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task RetryHandler_MessageHandlerMultipleTriesUntilSuccess()
+        {
+            // Arrange
+            var tries = 0;
+            var sent503 = false;
+
+            Func<HttpRequestMessage, HttpResponseMessage> handler = (request) =>
+            {
+                tries++;
+
+                // Return 503 for the first 2 tries
+                if (tries > 2)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                }
+                else
+                {
+                    sent503 = true;
+                    return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+                }
+            };
+
+            var testHandler = new TestHandler(handler);
+            var retryHandler = new RetryHandler(testHandler, 5);
+            var minTime = GetRetryMinTime(2, retryHandler);
+
+            var httpClient = new HttpClient(retryHandler);
+
+            // Act
+            var timer = new Stopwatch();
+            timer.Start();
+            var response = await httpClient.GetAsync("https://test.local/test.json");
+            timer.Stop();
+
+            // Assert
+            Assert.True(sent503);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.True(timer.Elapsed >= minTime,
+                string.Format("Expected this to take at least: {0} But it finished in: {1}",
+                    minTime,
+                    timer.Elapsed));
+        }
+
+        private static TimeSpan GetRetryMinTime(int tries, RetryHandler handler)
+        {
+            return TimeSpan.FromMilliseconds((tries - 1) * handler.RetryDelay.Milliseconds);
+        }
+
+        private class TestHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+
+            public TestHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+            {
+                _handler = handler;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                return Task.FromResult<HttpResponseMessage>(_handler(request));
+            }
+        }
+    }
+}

--- a/test/NuGet.Protocol.Test.Utility/StaticHttpHandler.cs
+++ b/test/NuGet.Protocol.Test.Utility/StaticHttpHandler.cs
@@ -62,9 +62,17 @@ namespace Test.Utility
             _messageHandler = messageHandler;
         }
 
-        public override HttpClientHandler MessageHandler
+        public override HttpClientHandler ClientHandler
         {
             get { return _messageHandler; }
+        }
+
+        public override HttpMessageHandler MessageHandler
+        {
+            get
+            {
+                return _messageHandler;
+            }
         }
     }
 


### PR DESCRIPTION
This change adds the RetryHandler back into the DataClient message handler. 5xx status codes and exceptions will be retried as part of the message handler.

Retries will be: 5 total tries with a 200ms wait in between each try (open to suggestions)

//cc @deepakaravindr @feiling @MeniZalzman @yishaigalatzer @johnataylor 
