### PR TITLE
Update the dependency on NuGet.Core to 2.8.8 so that the fix of NuGet/Home#776 gets incorporated into nuget v3

### DIFF
--- a/src/NuGet.Protocol.Core.v2/project.json
+++ b/src/NuGet.Protocol.Core.v2/project.json
@@ -13,7 +13,7 @@
         "NuGet.Configuration": "3.2.0-*",
         "NuGet.Packaging": "3.2.0-*",
         "NuGet.Protocol.Core.Types": "3.2.0-*",
-        "NuGet.Core": "2.8.6",
+        "NuGet.Core": "2.8.8-*",
         "NuGet.Common": { "type": "build",  "version": "3.2.0-*" }
     },
     "frameworks": {


### PR DESCRIPTION
Super simple change.

@zhili1208 @yishaigalatzer @emgarten @deepakaravindr 
