### PR TITLE
Added a ListCommandResource alongwith ListCommandResourceV2Provider

### DIFF
--- a/src/NuGet.Protocol.Core.Types/Resources/ListCommandResource.cs
+++ b/src/NuGet.Protocol.Core.Types/Resources/ListCommandResource.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Protocol.Core.Types
+{
+    public class ListCommandResource : INuGetResource
+    {
+        public string ListEndpoint { get; }
+        public ListCommandResource(string listEndpoint)
+        {
+            if (listEndpoint == null)
+            {
+                throw new ArgumentNullException(nameof(listEndpoint));
+            }
+
+            ListEndpoint = listEndpoint;
+        }
+
+        public Task<string> GetListEndpointAsync(CancellationToken token)
+        {
+            return Task.FromResult<string>(ListEndpoint);
+        }
+    }
+}

--- a/src/NuGet.Protocol.Core.Types/Resources/ListCommandResource.cs
+++ b/src/NuGet.Protocol.Core.Types/Resources/ListCommandResource.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace NuGet.Protocol.Core.Types
 {
     public class ListCommandResource : INuGetResource
     {
-        public string ListEndpoint { get; }
+        private readonly string _listEndpoint;
         public ListCommandResource(string listEndpoint)
         {
             if (listEndpoint == null)
@@ -14,12 +12,12 @@ namespace NuGet.Protocol.Core.Types
                 throw new ArgumentNullException(nameof(listEndpoint));
             }
 
-            ListEndpoint = listEndpoint;
+            _listEndpoint = listEndpoint;
         }
 
-        public Task<string> GetListEndpointAsync(CancellationToken token)
+        public string GetListEndpoint()
         {
-            return Task.FromResult<string>(ListEndpoint);
+            return _listEndpoint;
         }
     }
 }

--- a/src/NuGet.Protocol.Core.v2/FactoryExtensionsV2.cs
+++ b/src/NuGet.Protocol.Core.v2/FactoryExtensionsV2.cs
@@ -27,6 +27,7 @@ namespace NuGet.Protocol.Core.v2
             yield return new Lazy<INuGetResourceProvider>(() => new PackageRepositoryResourceV2Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new SearchLatestResourceV2Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new SimpleSearchResourceV2Provider());
+            yield return new Lazy<INuGetResourceProvider>(() => new ListCommandResourceV2Provider());
 
             yield break;
         }

--- a/src/NuGet.Protocol.Core.v2/ListCommandResourceV2Provider.cs
+++ b/src/NuGet.Protocol.Core.v2/ListCommandResourceV2Provider.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.Protocol.Core.v2
+{
+    public class ListCommandResourceV2Provider : V2ResourceProvider
+    {
+        public ListCommandResourceV2Provider()
+            : base(
+                  typeof(ListCommandResource),
+                  nameof(ListCommandResourceV2Provider),
+                  NuGetResourceProviderPositions.Last) { }
+
+        public override async Task<Tuple<bool, INuGetResource>> TryCreate(
+            SourceRepository source,
+            CancellationToken token)
+        {
+            ListCommandResource listCommandResource = null;
+
+            var v2repo = await GetRepository(source, token);
+
+            if (v2repo != null
+                && v2repo.V2Client != null
+                && !string.IsNullOrEmpty(v2repo.V2Client.Source))
+            {
+                // For a V2 package source, the source url is the list endpoint as well
+                listCommandResource = new ListCommandResource(v2repo.V2Client.Source);
+            }
+
+            return new Tuple<bool, INuGetResource>(listCommandResource != null, listCommandResource);
+        }
+    }
+}

--- a/src/NuGet.Protocol.Core.v3/Constants.cs
+++ b/src/NuGet.Protocol.Core.v3/Constants.cs
@@ -19,6 +19,7 @@ namespace NuGet.Protocol.Core.v3
 
     public static class ServiceTypes
     {
+        public const string VersionV2 = "/2.0.0";
         public const string TypeVersion = "/3.0.0-beta";
 
         public const string SearchQueryService = "SearchQueryService" + TypeVersion;
@@ -28,6 +29,7 @@ namespace NuGet.Protocol.Core.v3
         public const string RegistrationsBaseUrl = "RegistrationsBaseUrl" + TypeVersion;
         public const string ReportAbuse = "ReportAbuseUriTemplate" + TypeVersion;
         public const string Stats = "Stats" + TypeVersion;
+        public const string LegacyGallery = "LegacyGallery" + VersionV2;
     }
 
     public static class Properties

--- a/src/NuGet.Protocol.Core.v3/FactoryExtensionsV3.cs
+++ b/src/NuGet.Protocol.Core.v3/FactoryExtensionsV3.cs
@@ -39,6 +39,7 @@ namespace NuGet.Protocol.Core.v3
             yield return new Lazy<INuGetResourceProvider>(() => new RemoteV2FindPackageByIdResourceProvider());
             yield return new Lazy<INuGetResourceProvider>(() => new LocalV3FindPackageByIdResourceProvider());
             yield return new Lazy<INuGetResourceProvider>(() => new LocalV2FindPackageByIdResourceProvider());
+            yield return new Lazy<INuGetResourceProvider>(() => new ListCommandResourceV3Provider());
             yield break;
         }
     }

--- a/src/NuGet.Protocol.Core.v3/ListCommandResourceV3Provider.cs
+++ b/src/NuGet.Protocol.Core.v3/ListCommandResourceV3Provider.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.Protocol.Core.v3
+{
+    public class ListCommandResourceV3Provider : ResourceProvider
+    {
+        public ListCommandResourceV3Provider()
+            : base(
+                  typeof(ListCommandResource),
+                  nameof(ListCommandResourceV3Provider),
+                  "ListCommandResourceV2Provider") { }
+
+        public override async Task<Tuple<bool, INuGetResource>> TryCreate(
+            SourceRepository source,
+            CancellationToken token)
+        {
+            ListCommandResource listCommandResource = null;
+
+            var serviceIndex = await source.GetResourceAsync<ServiceIndexResourceV3>(token);
+
+            if (serviceIndex != null)
+            {
+                var baseUrl = serviceIndex[ServiceTypes.LegacyGallery].FirstOrDefault();
+                if (baseUrl != null)
+                {
+                    listCommandResource = new ListCommandResource(baseUrl.AbsoluteUri);
+                }
+            }
+
+            return new Tuple<bool, INuGetResource>(listCommandResource != null, listCommandResource);
+        }
+    }
+}


### PR DESCRIPTION
and ListCommandResourceV3Provider. For v3, this resource will return the
v2 endpoint specified in index.json as 'LegacyGallery/2.0.0'.
For v2, it will simply the return the v2 endpoint itself

@yishaigalatzer @emgarten @pranavkm @feiling 
