### PR TITLE
fixed https://github.com/NuGet/Home/issues/1172

### DIFF
--- a/src/NuGet.Frameworks/FrameworkNameProvider.cs
+++ b/src/NuGet.Frameworks/FrameworkNameProvider.cs
@@ -197,16 +197,17 @@ namespace NuGet.Frameworks
 
             profileNumber = -1;
 
-            var input = new HashSet<NuGetFramework>(supportedFrameworks, NuGetFramework.Comparer);
+            // Remove duplicate frameworks, ex: win+win8 -> win
+            var profileFrameworks = RemoveDuplicateFramework(supportedFrameworks);
 
             foreach (var pair in _portableFrameworks)
             {
                 // to match the required set must be less than or the same count as the input
                 // if we knew which frameworks were optional in the input we could rule out the lesser ones also
-                if (pair.Value.Count <= input.Count)
+                if (pair.Value.Count <= profileFrameworks.Count)
                 {
                     var reduced = new List<NuGetFramework>();
-                    foreach (var curFw in supportedFrameworks)
+                    foreach (var curFw in profileFrameworks)
                     {
                         var isOptional = false;
 
@@ -242,6 +243,60 @@ namespace NuGet.Frameworks
             }
 
             return false;
+        }
+
+        private HashSet<NuGetFramework> RemoveDuplicateFramework(IEnumerable<NuGetFramework> supportedFrameworks)
+        {
+            var result = new HashSet<NuGetFramework>(NuGetFramework.Comparer);
+            var existingFrameworks = new HashSet<NuGetFramework>(NuGetFramework.Comparer);
+
+            foreach (var framework in supportedFrameworks)
+            {
+                if (!existingFrameworks.Contains(framework))
+                {
+                    result.Add(framework);
+
+                    // Add in the existing framework (included here) and all equivalent frameworks  
+                    var equivalentFrameworks = GetAllEquivalentFrameworks(framework);
+
+                    existingFrameworks.UnionWith(equivalentFrameworks);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>  
+        /// Get all equivalent frameworks including the given framework  
+        /// </summary>  
+        private HashSet<NuGetFramework> GetAllEquivalentFrameworks(NuGetFramework framework)
+        {
+            // Loop through the frameworks, all frameworks that are not in results yet   
+            // will be added to toProcess to get the equivalent frameworks  
+            var toProcess = new Stack<NuGetFramework>();
+            var results = new HashSet<NuGetFramework>(NuGetFramework.Comparer);
+
+            toProcess.Push(framework);
+            results.Add(framework);
+
+            while (toProcess.Count > 0)
+            {
+                var current = toProcess.Pop();
+
+                HashSet<NuGetFramework> currentEquivalent = null;
+                if (_equivalentFrameworks.TryGetValue(current, out currentEquivalent))
+                {
+                    foreach (var equalFramework in currentEquivalent)
+                    {
+                        if (results.Add(equalFramework))
+                        {
+                            toProcess.Push(equalFramework);
+                        }
+                    }
+                }
+            }
+
+            return results;
         }
 
         // find all combinations that are equivalent

--- a/test/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
+++ b/test/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
@@ -255,10 +255,12 @@ namespace NuGet.Test
         [InlineData("portable-net45+wp8+win8+wpa")]
         [InlineData("portable-net45+win8+wp8+wpa81+monotouch+monoandroid")]
         [InlineData(".NETPortable,Version=v0.0,Profile=Profile259")]
-        // TODO: should bad framework names be supported?
-        //[InlineData(".NETPortable,Version=v0.0,Profile=net45+wp8+win8+wpa+monotouch+monoandroid")]
-        //[InlineData(".NETPortable,Version=v0.0,Profile=net45+wp8+win+wpa")]
-        //[InlineData(".NETPortable,Version=v0.0,Profile=net45+wp8+win8+wpa81")]
+        [InlineData("portable-net45+wp8+win+wpa+win8")]
+        [InlineData("portable-net45+wp8+win+wpa+netcore+netcore45")]
+        [InlineData("portable-net450+net4.5+net45+wp8+wpa+win8+wpa81")]
+        [InlineData("portable-win8+net45+wp8+wpa81+win8+win8")]
+        [InlineData("portable-net45+wp8+win+wpa+win8")]
+        [InlineData("portable-net45+wp8+win+wpa+win8+net4.5")]
         public void NuGetFramework_ParsePCLNormalizeTest(string framework)
         {
             Assert.Equal("Profile259", NuGetFramework.Parse(framework).Profile);


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/1172
the root cause for this bug is package frameworks contain duplicate frameworks, that make FrameworkNameProvider can't match the profile table to get profile number. in this case, they are win and win8. 
this fix is to remove duplicate frameworks.
