### PR TITLE
If the service index is available, it means that is a v3 package source,

### DIFF
--- a/src/NuGet.Protocol.Core.Types/Resources/ListCommandResource.cs
+++ b/src/NuGet.Protocol.Core.Types/Resources/ListCommandResource.cs
@@ -8,11 +8,7 @@ namespace NuGet.Protocol.Core.Types
 
         public ListCommandResource(string listEndpoint)
         {
-            if (listEndpoint == null)
-            {
-                throw new ArgumentNullException(nameof(listEndpoint));
-            }
-
+            // _listEndpoint may be null
             _listEndpoint = listEndpoint;
         }
 

--- a/src/NuGet.Protocol.Core.v3/ListCommandResourceV3Provider.cs
+++ b/src/NuGet.Protocol.Core.v3/ListCommandResourceV3Provider.cs
@@ -27,11 +27,12 @@ namespace NuGet.Protocol.Core.v3
 
             if (serviceIndex != null)
             {
+                // Since it is a v3 package source, always return a ListCommandResource object
+                // which may or may not contain a list endpoint.
+                // Returning null here will result in ListCommandResource
+                // getting returned for this very v3 package source as if it was a v2 package source
                 var baseUrl = serviceIndex[ServiceTypes.LegacyGallery].FirstOrDefault();
-                if (baseUrl != null)
-                {
-                    listCommandResource = new ListCommandResource(baseUrl.AbsoluteUri);
-                }
+                listCommandResource = new ListCommandResource(baseUrl?.AbsoluteUri);
             }
 
             var result = new Tuple<bool, INuGetResource>(listCommandResource != null, listCommandResource);


### PR DESCRIPTION
so always returns a ListCommandResource. If the list endpoint is not
available on the service index, ListCommandResource returned will have
a null endpoint

@yishaigalatzer @emgarten @MeniZalzman @feiling 
