### PR TITLE
If the service index is available, it means that is a v3 package source,

### DIFF
--- a/src/NuGet.Protocol.Core.Types/Resources/PushCommandResource.cs
+++ b/src/NuGet.Protocol.Core.Types/Resources/PushCommandResource.cs
@@ -8,11 +8,7 @@ namespace NuGet.Protocol.Core.Types
 
         public PushCommandResource(string pushEndpoint)
         {
-            if (pushEndpoint == null)
-            {
-                throw new ArgumentNullException(nameof(pushEndpoint));
-            }
-
+            // _pushEndpoint may be null
             _pushEndpoint = pushEndpoint;
         }
 

--- a/src/NuGet.Protocol.Core.v3/PushCommandResourceV3Provider.cs
+++ b/src/NuGet.Protocol.Core.v3/PushCommandResourceV3Provider.cs
@@ -25,11 +25,12 @@ namespace NuGet.Protocol.Core.v3
 
             if (serviceIndex != null)
             {
+                // Since it is a v3 package source, always return a PushCommandResource object
+                // which may or may not contain a push endpoint.
+                // Returning null here will result in ListCommandResource
+                // getting returned for this very v3 package source as if it was a v2 package source
                 var baseUrl = serviceIndex[ServiceTypes.PackagePublish].FirstOrDefault();
-                if (baseUrl != null)
-                {
-                    pushCommandResource = new PushCommandResource(baseUrl.AbsoluteUri);
-                }
+                pushCommandResource = new PushCommandResource(baseUrl?.AbsoluteUri);
             }
 
             var result = new Tuple<bool, INuGetResource>(pushCommandResource != null, pushCommandResource);


### PR DESCRIPTION
so always returns a PushCommandResource. If the push endpoint is not
available on the service index, PushCommandResource returned will have
a null endpoint

@yishaigalatzer @emgarten @MeniZalzman @feiling 
