### PR TITLE
Fix NuGet/Home#1216: NuGet incorrectly treating authenticated V3 feed as V2

### DIFF
--- a/src/NuGet.Protocol.Core.v3/ServiceIndexResourceV3Provider.cs
+++ b/src/NuGet.Protocol.Core.v3/ServiceIndexResourceV3Provider.cs
@@ -3,11 +3,12 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Net.Http;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Core.v3.Data;
 using NuGet.Versioning;
@@ -37,10 +38,65 @@ namespace NuGet.Protocol.Core.v3
             MaxCacheDuration = _defaultCacheDuration;
         }
 
+        // Read the source's end point to get the index json.
+        // Returns null when there is a failure.
+        private async Task<JObject> GetIndexJson(SourceRepository source, CancellationToken token)
+        {
+            var uri = new Uri(source.PackageSource.Source);
+            ICredentials credentials = CredentialStore.Instance.GetCredentials(uri);
+            while (true)
+            {
+                var messageHandlerResource = await source.GetResourceAsync<HttpHandlerResource>(token);
+                if (credentials != null)
+                {
+                    messageHandlerResource.ClientHandler.Credentials = credentials;
+                }
+
+                using (var client = new DataClient(messageHandlerResource))
+                {
+                    var response = await client.GetAsync(uri, token);
+
+                    if (response.IsSuccessStatusCode)
+                    {
+                        if (HttpHandlerResourceV3.CredentialsSuccessfullyUsed != null && credentials != null)
+                        {
+                            HttpHandlerResourceV3.CredentialsSuccessfullyUsed(uri, credentials);
+                        }
+
+                        try
+                        {
+                            var text = await response.Content.ReadAsStringAsync();
+                            return JObject.Parse(text);
+                        }
+                        catch (JsonReaderException)
+                        {
+                            return null;
+                        }
+                    }
+                    else if (response.StatusCode == HttpStatusCode.Unauthorized)
+                    {
+                        credentials = null;
+                        if (HttpHandlerResourceV3.PromptForCredentials != null)
+                        {
+                            credentials = HttpHandlerResourceV3.PromptForCredentials(uri);
+                        }
+
+                        if (credentials == null)
+                        {
+                            return null;
+                        }
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+            }
+        }
+
         public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
         {
             ServiceIndexResourceV3 index = null;
-
             var url = source.PackageSource.Source;
 
             // the file type can easily rule out if we need to request the url
@@ -56,31 +112,7 @@ namespace NuGet.Protocol.Core.v3
                 if (!_cache.TryGetValue(url, out cacheInfo) ||
                     entryValidCutoff > cacheInfo.CachedTime)
                 {
-                    var messageHandlerResource = await source.GetResourceAsync<HttpHandlerResource>(token);
-
-                    var client = new DataClient(messageHandlerResource);
-
-                    JObject json;
-
-                    try
-                    {
-                        json = await client.GetJObjectAsync(new Uri(url), token);
-                    }
-                    catch (JsonReaderException)
-                    {
-                        var entry = new ServiceIndexCacheInfo { CachedTime = utcNow };
-                        _cache.AddOrUpdate(url, entry, (key, value) => entry);
-
-                        return new Tuple<bool, INuGetResource>(false, null);
-                    }
-                    catch (HttpRequestException)
-                    {
-                        var entry = new ServiceIndexCacheInfo { CachedTime = utcNow };
-                        _cache.AddOrUpdate(url, entry, (key, value) => entry);
-
-                        return new Tuple<bool, INuGetResource>(false, null);
-                    }
-
+                    var json = await GetIndexJson(source, token);
                     if (json != null)
                     {
                         // Use SemVer instead of NuGetVersion, the service index should always be
@@ -94,6 +126,13 @@ namespace NuGet.Protocol.Core.v3
                         {
                             index = new ServiceIndexResourceV3(json, utcNow);
                         }
+                    }
+                    else
+                    {
+                        var entry = new ServiceIndexCacheInfo { CachedTime = utcNow };
+                        _cache.AddOrUpdate(url, entry, (key, value) => entry);
+
+                        return new Tuple<bool, INuGetResource>(false, null);
                     }
                 }
                 else


### PR DESCRIPTION
The problem is that authentication was not supported for V3 feed. So when nuget checks
if a feed is V3 or not, since accessing index.json fails because of authentication failure,
nuget will treat the feed as V2.

This change added authentication support.

@deepakaravindr @emgarten @yishaigalatzer @zhili1208 
