### PR TITLE
Fixes nuget.exe push with https://www.nuget.org/api/v2/Package which is not a package source

### DIFF
--- a/src/NuGet.Protocol.Core.v2/PushCommandResourceV2Provider.cs
+++ b/src/NuGet.Protocol.Core.v2/PushCommandResourceV2Provider.cs
@@ -14,20 +14,14 @@ namespace NuGet.Protocol.Core.v2
                   NuGetResourceProviderPositions.Last)
         { }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(
+        public override Task<Tuple<bool, INuGetResource>> TryCreate(
             SourceRepository source,
             CancellationToken token)
         {
-            PushCommandResource pushCommandResource = null;
-            var v2Repo = await GetRepository(source, token);
-
-            if (v2Repo != null && v2Repo.V2Client != null && !string.IsNullOrEmpty(v2Repo.V2Client.Source))
-            {
-                pushCommandResource = new PushCommandResource(v2Repo.V2Client.Source);
-            }
+            var pushCommandResource = new PushCommandResource(source?.PackageSource?.Source);
 
             var result = new Tuple<bool, INuGetResource>(pushCommandResource != null, pushCommandResource);
-            return result;
+            return Task.FromResult(result);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/1237
SourceRepository need not be a package source for PushCommand.
So, simply return the SourceRepository.PackageSource.Source

@yishaigalatzer @emgarten @MeniZalzman @feiling 
