### PR TITLE
Cache control for project.json restore

### DIFF
--- a/src/NuGet.Commands/RestoreCommand.cs
+++ b/src/NuGet.Commands/RestoreCommand.cs
@@ -181,9 +181,9 @@ namespace NuGet.Commands
             }
 
             context.LocalLibraryProviders.Add(
-                new SourceRepositoryDependencyProvider(nugetRepository, _log));
+                new SourceRepositoryDependencyProvider(nugetRepository, _log, _request.CacheContext));
 
-            foreach (var provider in _request.Sources.Select(s => CreateProviderFromSource(s, _request.NoCache)))
+            foreach (var provider in _request.Sources.Select(s => CreateProviderFromSource(s, _request.CacheContext)))
             {
                 context.RemoteLibraryProviders.Add(provider);
             }
@@ -861,12 +861,12 @@ namespace NuGet.Commands
                 token: token);
         }
 
-        private IRemoteDependencyProvider CreateProviderFromSource(PackageSource source, bool noCache)
+        private IRemoteDependencyProvider CreateProviderFromSource(PackageSource source, SourceCacheContext cacheContext)
         {
             _log.LogVerbose(Strings.FormatLog_UsingSource(source.Source));
 
             var nugetRepository = Repository.Factory.GetCoreV3(source.Source);
-            return new SourceRepositoryDependencyProvider(nugetRepository, _log, noCache);
+            return new SourceRepositoryDependencyProvider(nugetRepository, _log, cacheContext);
         }
     }
 }

--- a/src/NuGet.Commands/RestoreRequest.cs
+++ b/src/NuGet.Commands/RestoreRequest.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.ProjectModel;
+using NuGet.Protocol.Core.Types;
 
 namespace NuGet.Commands
 {
@@ -26,6 +28,8 @@ namespace NuGet.Commands
             CompatibilityProfiles = new HashSet<FrameworkRuntimePair>();
 
             PackagesDirectory = packagesDirectory;
+
+            CacheContext = new SourceCacheContext();
         }
 
         /// <summary>
@@ -69,9 +73,9 @@ namespace NuGet.Commands
         public int MaxDegreeOfConcurrency { get; set; } = DefaultDegreeOfConcurrency;
 
         /// <summary>
-        /// If set, ignore the cache when downloading packages
+        /// Cache settings
         /// </summary>
-        public bool NoCache { get; set; }
+        public SourceCacheContext CacheContext { get; set; }
 
         /// <summary>
         /// Additional compatibility profiles to check compatibility with.

--- a/src/NuGet.DependencyResolver/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.DependencyResolver/SourceRepositoryDependencyProvider.cs
@@ -18,24 +18,17 @@ namespace NuGet.DependencyResolver
     {
         private readonly SourceRepository _sourceRepository;
         private readonly ILogger _logger;
-        private readonly bool _noCache;
+        private readonly SourceCacheContext _cacheContext;
         private FindPackageByIdResource _findPackagesByIdResource;
 
         public SourceRepositoryDependencyProvider(
             SourceRepository sourceRepository,
-            ILogger logger)
-            : this(sourceRepository, logger, noCache: false)
-        {
-        }
-
-        public SourceRepositoryDependencyProvider(
-            SourceRepository sourceRepository,
             ILogger logger,
-            bool noCache)
+            SourceCacheContext cacheContext)
         {
             _sourceRepository = sourceRepository;
             _logger = logger;
-            _noCache = noCache;
+            _cacheContext = cacheContext;
         }
 
         public bool IsHttp => _sourceRepository.PackageSource.IsHttp;
@@ -156,7 +149,7 @@ namespace NuGet.DependencyResolver
             {
                 _findPackagesByIdResource = await _sourceRepository.GetResourceAsync<FindPackageByIdResource>();
                 _findPackagesByIdResource.Logger = _logger;
-                _findPackagesByIdResource.NoCache = _noCache;
+                _findPackagesByIdResource.CacheContext = _cacheContext;
             }
         }
     }

--- a/src/NuGet.Protocol.Core.Types/SourceCacheContext.cs
+++ b/src/NuGet.Protocol.Core.Types/SourceCacheContext.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace NuGet.Protocol.Core.Types
+{
+    /// <summary>
+    /// Cache control settings for the V3 disk cache.
+    /// </summary>
+    public class SourceCacheContext
+    {
+        /// <summary>
+        /// Default amount of time to cache version lists.
+        /// </summary>
+        private static readonly TimeSpan DefaultCacheAgeLimitList = TimeSpan.FromMinutes(30);
+
+        /// <summary>
+        /// Default amount of time to cache nupkgs.
+        /// </summary>
+        private static readonly TimeSpan DefaultCacheAgeLimitNupkg = TimeSpan.FromHours(24);
+
+        /// <summary>
+        /// If set, ignore the disk cache when listing and downloading packages
+        /// </summary>
+        public bool NoCache { get; set; }
+
+        /// <summary>
+        /// Package version lists from the server older than this date
+        /// will be fetched from the server.
+        /// </summary>
+        /// <remarks>This will be ignored if <see cref="NoCache"/> is true.</remarks>
+        /// <remarks>If the value is null the default expiration will be used.</remarks>
+        public DateTimeOffset? ListMaxAge { get; set; }
+
+        /// <summary>
+        /// Nupkgs from the server older than this date will be fetched from the server.
+        /// </summary>
+        /// <remarks>This will be ignored if <see cref="NoCache"/> is true.</remarks>
+        /// <remarks>If the value is null the default expiration will be used.</remarks>
+        public DateTimeOffset? NupkgMaxAge { get; set; }
+
+
+        /// <summary>
+        /// Package version lists from the server older than this time span
+        /// will be fetched from the server.
+        /// </summary>
+        public TimeSpan ListMaxAgeTimeSpan
+        {
+            get
+            {
+                return GetCacheTime(ListMaxAge, DefaultCacheAgeLimitList);
+            }
+        }
+
+        /// <summary>
+        /// Packages from the server older than this time span
+        /// will be fetched from the server.
+        /// </summary>
+        public TimeSpan NupkgMaxAgeTimeSpan
+        {
+            get
+            {
+                return GetCacheTime(ListMaxAge, DefaultCacheAgeLimitNupkg);
+            }
+        }
+
+        private TimeSpan GetCacheTime(DateTimeOffset? maxAge, TimeSpan defaultTime)
+        {
+            var timeSpan = TimeSpan.Zero;
+
+            if (!NoCache)
+            {
+                // Default
+                timeSpan = defaultTime;
+
+                // If the max age is set use that instead of the default
+                if (ListMaxAge.HasValue)
+                {
+                    var difference = DateTimeOffset.UtcNow.Subtract(ListMaxAge.Value);
+
+                    Debug.Assert(difference >= TimeSpan.Zero, "Invalid cache time");
+
+                    if (difference >= TimeSpan.Zero)
+                    {
+                        timeSpan = difference;
+                    }
+                }
+            }
+
+            return timeSpan;
+        }
+    }
+}

--- a/src/NuGet.Protocol.Core.v3/FindPackageByIdResource.cs
+++ b/src/NuGet.Protocol.Core.v3/FindPackageByIdResource.cs
@@ -13,7 +13,7 @@ namespace NuGet.Protocol.Core.Types
 {
     public abstract class FindPackageByIdResource : INuGetResource
     {
-        public virtual bool NoCache { get; set; }
+        public virtual SourceCacheContext CacheContext { get; set; }
 
         public virtual ILogger Logger { get; set; }
 


### PR DESCRIPTION
This change adds a CacheContext to RestoreRequest to provide more options beyond NoCache. For package installs and updates restore will go by the time the package operation was started, all older cache entries for the packages restored will be cleared out of the v3-cache. After the operation rebuilding and restoring from the command line will work using the updated v3-cache content, instead of having to retrieving it again which would be the case with NoCache=true.

https://github.com/NuGet/Home/issues/1096

//cc @yishaigalatzer @davidfowl @MeniZalzman @deepakaravindr @feiling 
