### PR TITLE
Fix of NuGet/Home#1253: Don't fall thru when v3 feed failed

### DIFF
--- a/src/NuGet.Protocol.Core.v3/Properties/Strings.Designer.cs
+++ b/src/NuGet.Protocol.Core.v3/Properties/Strings.Designer.cs
@@ -339,9 +339,25 @@ namespace NuGet.Protocol.Core.v3
         }
 
         /// <summary>
+        /// The source does not have the 'version' property.
+        /// </summary>
+        internal static string Protocol_MissingVersion
+        {
+            get { return GetString("Protocol_MissingVersion"); }
+        }
+
+        /// <summary>
+        /// The source version is not supported: '{0}'.
+        /// </summary>
+        internal static string Protocol_UnsupportedVersion
+        {
+            get { return GetString("Protocol_UnsupportedVersion"); }
+        }
+
+        /// <summary>
         /// An error occurred while retrieving package metadata for '{0}' from source '{1}'.
         /// </summary>
-        internal static string FormatProtocol_PackageMetadataError(object p0, object p1)
+            internal static string FormatProtocol_PackageMetadataError(object p0, object p1)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("Protocol_PackageMetadataError"), p0, p1);
         }

--- a/src/NuGet.Protocol.Core.v3/Strings.resx
+++ b/src/NuGet.Protocol.Core.v3/Strings.resx
@@ -177,8 +177,14 @@
   <data name="Protocol_MissingSearchService" xml:space="preserve">
     <value>The source does not have a Search service!</value>
   </data>
+  <data name="Protocol_MissingVersion" xml:space="preserve">
+    <value>The source does not have the 'version' property.</value>
+  </data>
   <data name="Protocol_PackageMetadataError" xml:space="preserve">
     <value>An error occurred while retrieving package metadata for '{0}' from source '{1}'.</value>
+  </data>
+  <data name="Protocol_UnsupportedVersion" xml:space="preserve">
+    <value>The source version is not supported: '{0}'.</value>
   </data>
   <data name="RequiredFeatureUnsupportedException_DefaultMessageWithFeature" xml:space="preserve">
     <value>The '{0}' installation feature was required by a package but is not supported on the current host.</value>


### PR DESCRIPTION
Now if there is a failure, an exception will get thrown so GetResource fails immediately so no fall thru will happens. Also the V3 resource is cached only when it is successfully created.

@deepakaravindr @emgarten @yishaigalatzer @zhili1208 
