### PR TITLE
PackagesConfigWriter update support

### DIFF
--- a/src/NuGet.Packaging/PackagesConfigWriter.cs
+++ b/src/NuGet.Packaging/PackagesConfigWriter.cs
@@ -388,14 +388,14 @@ namespace NuGet.Packaging
                 // When the attribute is not specified a value in the new node
                 if (string.IsNullOrEmpty(newValue))
                 {
-                    if (!name.Equals(XName.Get(PackagesConfig.allowedVersionsAttributeName)))
+                    if (name.Equals(XName.Get(PackagesConfig.RequireInstallAttributeName)))
                     {
-                        // Remove the attribute, such as requirementReinstallation, developmentDependency and userInstalled.
-                        existingNode.SetAttributeValue(name, null);
+                        // Remove the requirementReinstallation attribute.
+                        existingNode.SetAttributeValue(name, value: null);
                     }
                     else
                     {
-                        // no-op. Keep the allowedVersion attribute as-is.
+                        // no-op. Keep the allowedVersion attribute and all other attributes as-is.
                     }
                 }
                 else

--- a/src/NuGet.Packaging/PackagesConfigWriter.cs
+++ b/src/NuGet.Packaging/PackagesConfigWriter.cs
@@ -186,7 +186,7 @@ namespace NuGet.Packaging
         /// <summary>
         /// Update a package entry using the original entry as a base if it exists.
         /// </summary>
-        public void UpdatePackageEntry(XDocument originalConfig, PackageReference newEntry)
+        public void UpdateOrAddPackageEntry(XDocument originalConfig, PackageReference newEntry)
         {
             if (originalConfig == null)
             {

--- a/test/NuGet.Packaging.Test/PackagesConfigWriterTests.cs
+++ b/test/NuGet.Packaging.Test/PackagesConfigWriterTests.cs
@@ -160,7 +160,7 @@ namespace NuGet.Packaging.Test
 
             using (PackagesConfigWriter writer = new PackagesConfigWriter(stream2, true))
             {
-                writer.UpdatePackageEntry(xml, packageReferenceB);
+                writer.UpdateOrAddPackageEntry(xml, packageReferenceB);
             }
 
             stream2.Seek(0, SeekOrigin.Begin);

--- a/test/NuGet.Packaging.Test/PackagesConfigWriterTests.cs
+++ b/test/NuGet.Packaging.Test/PackagesConfigWriterTests.cs
@@ -342,7 +342,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal("utf-8", xml.Declaration.Encoding);
 
             var packageNode = xml.Descendants(PackagesConfig.PackageNodeName).FirstOrDefault();
-            Assert.Equal(packageNode.ToString(), "<package id=\"packageA\" version=\"1.0.1\" targetFramework=\"net45\" protocolVersion=\"V2\" />");
+            Assert.Equal(packageNode.ToString(), "<package id=\"packageA\" version=\"1.0.1\" targetFramework=\"net45\" userInstalled=\"true\" protocolVersion=\"V2\" />");
         }
     }
 }

--- a/test/NuGet.Packaging.Test/PackagesConfigWriterTests.cs
+++ b/test/NuGet.Packaging.Test/PackagesConfigWriterTests.cs
@@ -134,6 +134,55 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
+        public void PackagesConfigWriter_UpdateAttributesFromOriginalConfig()
+        {
+            // Arrange
+            var stream = new MemoryStream();
+            var stream2 = new MemoryStream();
+
+            // Act
+            using (PackagesConfigWriter writer = new PackagesConfigWriter(stream, true))
+            {
+                var vensionRange = new VersionRange(NuGetVersion.Parse("0.5.0"));
+                var packageIdentityA = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.1"));
+                var packageReferenceA = new PackageReference(packageIdentityA, NuGetFramework.Parse("net45"),
+                    userInstalled: false, developmentDependency: false, requireReinstallation: true, allowedVersions: vensionRange);
+
+                writer.AddPackageEntry(packageReferenceA);
+            }
+
+            stream.Seek(0, SeekOrigin.Begin);
+            var xml = XDocument.Load(stream);
+
+            var packageIdentityB = new PackageIdentity("packageA", NuGetVersion.Parse("3.0.1"));
+            var packageReferenceB = new PackageReference(packageIdentityB, NuGetFramework.Parse("dnxcore50"),
+                userInstalled: false, developmentDependency: false, requireReinstallation: false);
+
+            using (PackagesConfigWriter writer = new PackagesConfigWriter(stream2, true))
+            {
+                writer.UpdatePackageEntry(xml, packageReferenceB);
+            }
+
+            stream2.Seek(0, SeekOrigin.Begin);
+            var xml2 = XDocument.Load(stream2);
+            var reader = new PackagesConfigReader(xml2);
+
+            // Assert
+
+            var packages = reader.GetPackages().ToArray();
+            Assert.Equal("1", packages.Count().ToString());
+            Assert.Equal("packageA", packages[0].PackageIdentity.Id);
+            Assert.Equal("3.0.1", packages[0].PackageIdentity.Version.ToNormalizedString());
+            Assert.Equal("dnxcore5", packages[0].TargetFramework.GetShortFolderName());
+
+            // Verify allowedVersions attribute is kept after package update.
+            Assert.Equal("[0.5.0, )", packages[0].AllowedVersions.ToNormalizedString());
+
+            // Verify that RequireReinstallation attribute is removed after package upate.
+            Assert.Equal("False", packages[0].RequireReinstallation.ToString());
+        }
+
+        [Fact]
         public void PackagesConfigWriter_UpdateError()
         {
             // Arrange


### PR DESCRIPTION
This change adds PackagesConfigWriter support for adding a new entry based on an entry from the original packages.config.

Previously unknown attributes were being dropped, this change also fixes that and persists all attributes except for require re-installation.

https://github.com/NuGet/Home/issues/1130

//cc @deepakaravindr @zhili1208 @MeniZalzman @yishaigalatzer 
