### PR TITLE
Fix library file slashes

### DIFF
--- a/src/NuGet.Commands/CompatilibityChecker.cs
+++ b/src/NuGet.Commands/CompatilibityChecker.cs
@@ -178,10 +178,18 @@ namespace NuGet.Commands
                     using (var nupkgStream = File.OpenRead(package.ZipPath))
                     {
                         var packageReader = new PackageReader(nupkgStream);
-                        files = packageReader
-                                .GetFiles()
-                                .Select(p => p.Replace(Path.DirectorySeparatorChar, '/'))
-                                .ToList();
+
+                        if (Path.DirectorySeparatorChar != '/')
+                        {
+                            files = packageReader
+                                    .GetFiles()
+                                    .Select(p => p.Replace(Path.DirectorySeparatorChar, '/'))
+                                    .ToList();
+                        }
+                        else
+                        {
+                            files = packageReader.GetFiles().ToList();
+                        }
                     }
                 }
 

--- a/src/NuGet.Commands/LockFileUtils.cs
+++ b/src/NuGet.Commands/LockFileUtils.cs
@@ -52,16 +52,31 @@ namespace NuGet.Commands
                 using (var nupkgStream = File.OpenRead(package.ZipPath))
                 {
                     var packageReader = new PackageReader(nupkgStream);
-                    files = packageReader
-                        .GetFiles()
-                        .Select(p => p.Replace(Path.DirectorySeparatorChar, '/'))
-                        .ToList();
-
+                    if (Path.DirectorySeparatorChar != '/')
+                    {
+                        files = packageReader
+                            .GetFiles()
+                            .Select(p => p.Replace(Path.DirectorySeparatorChar, '/'))
+                            .ToList();
+                    }
+                    else
+                    {
+                        files = packageReader
+                            .GetFiles()
+                            .ToList();
+                    }
                 }
             }
             else
             {
-                files = library.Files.Select(p => p.Replace(Path.DirectorySeparatorChar, '/')).ToList();
+                if (Path.DirectorySeparatorChar != '/')
+                {
+                    files = library.Files.Select(p => p.Replace(Path.DirectorySeparatorChar, '/')).ToList();
+                }
+                else
+                {
+                    files = library.Files;
+                }
             }
 
             contentItems.Load(files);

--- a/src/NuGet.Commands/RestoreCommand.cs
+++ b/src/NuGet.Commands/RestoreCommand.cs
@@ -515,6 +515,13 @@ namespace NuGet.Commands
                         sha512,
                         correctedPackageName: library.Name);
                 }
+                else
+                {
+                    // Fix slashes for content model patterns
+                    lockFileLib.Files = lockFileLib.Files
+                        .Select(p => p.Replace(Path.DirectorySeparatorChar, '/'))
+                        .ToList();
+                }
 
                 lockFile.Libraries.Add(lockFileLib);
 

--- a/src/NuGet.Commands/RestoreCommand.cs
+++ b/src/NuGet.Commands/RestoreCommand.cs
@@ -515,7 +515,7 @@ namespace NuGet.Commands
                         sha512,
                         correctedPackageName: library.Name);
                 }
-                else
+                else if (Path.DirectorySeparatorChar != '/')
                 {
                     // Fix slashes for content model patterns
                     lockFileLib.Files = lockFileLib.Files


### PR DESCRIPTION
The content model expects all slashes to be forward slashes. In some scenarios the existing lock file is used to skip reading packages from disk, and in these cases back slashes can get in and the content model will fail to recognize build items.

//cc @deepakaravindr @yishaigalatzer 

https://github.com/NuGet/Home/issues/1288
