### PR TITLE
Fix NuGet/Home#1300: V3 install/restore only uses credentials for index.json.

### DIFF
--- a/src/NuGet.Protocol.Core.v3/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Protocol.Core.v3/HttpHandlerResourceV3Provider.cs
@@ -14,8 +14,6 @@ namespace NuGet.Protocol.Core.v3
 {
     public class HttpHandlerResourceV3Provider : ResourceProvider
     {
-        private static readonly string[] _authenticationSchemes = new[] { "Basic", "NTLM", "Negotiate" };
-
         public HttpHandlerResourceV3Provider()
             : base(typeof(HttpHandlerResource),
                   nameof(HttpHandlerResourceV3Provider),
@@ -66,12 +64,7 @@ namespace NuGet.Protocol.Core.v3
                 && !String.IsNullOrEmpty(packageSource.UserName)
                 && !String.IsNullOrEmpty(packageSource.Password))
             {
-                var cache = new CredentialCache();
-                foreach (var scheme in _authenticationSchemes)
-                {
-                    cache.Add(uri, scheme, new NetworkCredential(packageSource.UserName, packageSource.Password));
-                }
-                credential = cache;
+                credential = new NetworkCredential(packageSource.UserName, packageSource.Password);
             }
 
             if (proxy != null)


### PR DESCRIPTION
The problem is that in HttpHandlerResourceV3Provider, when there is a credential saved in
nuget.config, the code creates CredentialCache, then adds NetworkCredential into the cache, with the
uri of the source as key. However, for V3 source, other resources most likely have different URIs
from index.json endpoint. Thus, this CredentialCache won't be able to provide credentials for other
resources. It only works for index.json.

The fix is to just create a normal NetworkCredential object.

@deepakaravindr @emgarten @yishaigalatzer @zhili1208 
