### PR TITLE
Allow prerelease versions during resolver conflict checks

### DIFF
--- a/src/NuGet.Packaging.Core.Types/PackageDependency.cs
+++ b/src/NuGet.Packaging.Core.Types/PackageDependency.cs
@@ -52,8 +52,7 @@ namespace NuGet.Packaging.Core
         /// </summary>
         public void SetIncludePrerelease()
         {
-            _versionRange = new VersionRange(_versionRange.MinVersion, _versionRange.IsMinInclusive, _versionRange.MaxVersion,
-                _versionRange.IsMaxInclusive, true, _versionRange.Float);
+            _versionRange = VersionRange.SetIncludePrerelease(_versionRange, includePrerelease: true);
         }
 
         public bool Equals(PackageDependency other)

--- a/src/NuGet.Protocol.Core.v3/DependencyInfo/Utils.cs
+++ b/src/NuGet.Protocol.Core.v3/DependencyInfo/Utils.cs
@@ -27,11 +27,6 @@ namespace NuGet.Protocol.Core.v3.DependencyInfo
             return JObject.Parse(json);
         }
 
-        public static VersionRange SetIncludePrerelease(VersionRange range, bool includePrerelease)
-        {
-            return new VersionRange(range.MinVersion, range.IsMinInclusive, range.MaxVersion, range.IsMaxInclusive, includePrerelease);
-        }
-
         public static string Indent(int depth)
         {
             return new string(Enumerable.Repeat(' ', depth).ToArray());
@@ -68,7 +63,7 @@ namespace NuGet.Protocol.Core.v3.DependencyInfo
                 return Enumerable.Empty<JObject>();
             }
 
-            var preFilterRange = Utils.SetIncludePrerelease(range, true);
+            var preFilterRange = VersionRange.SetIncludePrerelease(range, includePrerelease: true);
 
             IList<Task<JObject>> rangeTasks = new List<Task<JObject>>();
 

--- a/src/NuGet.Versioning/VersionRangeFactory.cs
+++ b/src/NuGet.Versioning/VersionRangeFactory.cs
@@ -226,6 +226,33 @@ namespace NuGet.Versioning
         }
 
         /// <summary>
+        /// Modify an existing range to allow or disallow prerelease versions.
+        /// </summary>
+        /// <param name="range">Existing version range to modify.</param>
+        /// <param name="includePrerelease">True if Satisfies() should allow prerelease versions.</param>
+        /// <returns>A modified version range.</returns>
+        public static VersionRange SetIncludePrerelease(VersionRange range, bool includePrerelease)
+        {
+            if (range.IncludePrerelease == includePrerelease)
+            {
+                // The range is already has this prerelease setting.
+                return range;
+            }
+            else
+            {
+                // Copy the range and apply the new include prerelease setting.
+                return new VersionRange(
+                    range.MinVersion,
+                    range.IsMinInclusive,
+                    range.MaxVersion,
+                    range.IsMaxInclusive,
+                    includePrerelease,
+                    floatRange: range.Float,
+                    originalString: range.OriginalString);
+            }
+        }
+
+        /// <summary>
         /// Returns the smallest range that includes all given versions.
         /// </summary>
         public static VersionRange Combine(IEnumerable<NuGetVersion> versions)

--- a/test/NuGet.Versioning.Test/VersionRangeTests.cs
+++ b/test/NuGet.Versioning.Test/VersionRangeTests.cs
@@ -9,6 +9,58 @@ namespace NuGet.Versioning.Test
 {
     public class VersionRangeTests
     {
+        [Theory]
+        [InlineData("[1.0.0]")]
+        [InlineData("[1.0.0, 2.0.0]")]
+        [InlineData("[1.0.0, 2.0.0]")]
+        [InlineData("1.0.0")]
+        [InlineData("1.0.0-beta")]
+        [InlineData("(1.0.0-beta, 2.0.0-alpha)")]
+        [InlineData("(1.0.0-beta, 2.0.0)")]
+        [InlineData("(1.0.0, 2.0.0-alpha)")]
+        [InlineData("1.0.0-beta-*")]
+        [InlineData("[1.0.0-beta-*, ]")]
+        public void VersionRange_SetIncludePrerelease_True(string s)
+        {
+            // Arrange
+            var range = VersionRange.Parse(s);
+
+            // Act
+            var updated = VersionRange.SetIncludePrerelease(range, true);
+
+            // Assert
+            Assert.Equal(range.IsFloating, updated.IsFloating);
+            Assert.Equal(range.Float, updated.Float);
+            Assert.True(updated.IncludePrerelease);
+            Assert.Equal(range.ToNormalizedString(), updated.ToNormalizedString());
+        }
+
+        [Theory]
+        [InlineData("[1.0.0]")]
+        [InlineData("[1.0.0, 2.0.0]")]
+        [InlineData("[1.0.0, 2.0.0]")]
+        [InlineData("1.0.0")]
+        [InlineData("1.0.0-beta")]
+        [InlineData("(1.0.0-beta, 2.0.0-alpha)")]
+        [InlineData("(1.0.0-beta, 2.0.0)")]
+        [InlineData("(1.0.0, 2.0.0-alpha)")]
+        [InlineData("1.0.0-beta-*")]
+        [InlineData("[1.0.0-beta-*, ]")]
+        public void VersionRange_SetIncludePrerelease_False(string s)
+        {
+            // Arrange
+            var range = VersionRange.Parse(s);
+
+            // Act
+            var updated = VersionRange.SetIncludePrerelease(range, false);
+
+            // Assert
+            Assert.Equal(range.IsFloating, updated.IsFloating);
+            Assert.Equal(range.Float, updated.Float);
+            Assert.False(updated.IncludePrerelease);
+            Assert.Equal(range.ToNormalizedString(), updated.ToNormalizedString());
+        }
+
         [Fact]
         public void ParseVersionRangeSingleDigit()
         {


### PR DESCRIPTION
This change updates the resolver dependency conflict check to allow prerelease versions if one was selected during the graph walk. By default ranges with stable versions do not allow prerelease versions, but at this point in the code if a prerelease version was selected it means that the dependency constraint allowed it and it should be accepted here.

I've also added VersionRange.SetIncludePrerelease and cleaned up other parts of the code performing this same action.

Additional tests for this are in packagemanagement in the command line tests.

https://github.com/NuGet/Home/issues/1304

//cc @davidfowl @yishaigalatzer @deepakaravindr @MeniZalzman @feiling 
