### PR TITLE
Add configurable package download timeout

### DIFF
--- a/src/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -12,6 +12,11 @@ namespace NuGet.Configuration
         /// </summary>
         public const int DefaultProtocolVersion = 2;
 
+        /// <summary>
+        /// The default timeout when downloading packages.
+        /// </summary>
+        public static readonly TimeSpan DefaultDownloadTimeout = TimeSpan.FromMinutes(5);
+
         private readonly int _hashCode;
         private bool? _isHttp;
 
@@ -43,6 +48,11 @@ namespace NuGet.Configuration
         /// Gets or sets the protocol version of the source. Defaults to 2.
         /// </summary>
         public int ProtocolVersion { get; set; } = DefaultProtocolVersion;
+
+        /// <summary>
+        /// Gets or sets the maximum timeout in seconds when downloading packages from the source.
+        /// </summary>
+        public TimeSpan DownloadTimeout { get; set; } = DefaultDownloadTimeout;
 
         public bool IsHttp
         {

--- a/src/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -246,6 +246,7 @@ namespace NuGet.Configuration
             }
 
             packageSource.ProtocolVersion = ReadProtocolVersion(setting);
+            packageSource.DownloadTimeout = ReadDownloadTimeout(setting);
 
             return packageSource;
         }
@@ -262,6 +263,20 @@ namespace NuGet.Configuration
             }
 
             return PackageSource.DefaultProtocolVersion;
+        }
+
+        private static TimeSpan ReadDownloadTimeout(SettingValue setting)
+        {
+            string downloadTimeoutString;
+            int downloadTimeout;
+            if (setting.AdditionalData.TryGetValue(ConfigurationContants.DownloadTimeoutAttribute, out downloadTimeoutString)
+                && int.TryParse(downloadTimeoutString, out downloadTimeout)
+                && downloadTimeout > 0)
+            {
+                return TimeSpan.FromSeconds(downloadTimeout);
+            }
+
+            return PackageSource.DefaultDownloadTimeout;
         }
 
         private static int AddOrUpdateIndexedSource(

--- a/src/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -40,5 +40,7 @@ namespace NuGet.Configuration
         internal static string ValueAttribute = "value";
 
         internal static string ProtocolVersionAttribute = "protocolVersion";
+
+        internal static string DownloadTimeoutAttribute = "downloadTimeout";
     }
 }

--- a/src/NuGet.Protocol.Core.v3/DownloadResourceV3Provider.cs
+++ b/src/NuGet.Protocol.Core.v3/DownloadResourceV3Provider.cs
@@ -36,6 +36,7 @@ namespace NuGet.Protocol.Core.v3
                     var messageHandlerResource = await source.GetResourceAsync<HttpHandlerResource>(token);
 
                     var client = new DataClient(messageHandlerResource);
+                    client.Timeout = source.PackageSource.DownloadTimeout;
 
                     curResource = new DownloadResourceV3(client, registrationResource);
 


### PR DESCRIPTION
Large package downloads currently time out at 1:40min due to the Timeout property on DataClient (HttpClient), which makes it impossible to restore very large packages.

This change adds a configurable property 'downloadTimeout' on a package source.

This change also increases the default to 5 minutes (instead of the 1:40 default in HttpClient).  Please let me know if you disagree with this default value.
