### PR TITLE
Improve nuspec handling

### DIFF
--- a/src/NuGet.Commands/LockFileUtils.cs
+++ b/src/NuGet.Commands/LockFileUtils.cs
@@ -81,9 +81,27 @@ namespace NuGet.Commands
 
             contentItems.Load(files);
 
+            NuspecReader nuspec = null;
+
             var nuspecPath = defaultPackagePathResolver.GetManifestFilePath(package.Id, package.Version);
 
-            var nuspec = new NuspecReader(File.OpenRead(nuspecPath));
+            if (File.Exists(nuspecPath))
+            {
+                using (var stream = File.OpenRead(nuspecPath))
+                {
+                    nuspec = new NuspecReader(stream);
+                }
+            }
+            else
+            {
+                var dir = defaultPackagePathResolver.GetPackageDirectory(package.Id, package.Version);
+                var folderReader = new PackageFolderReader(dir);
+
+                using (var stream = folderReader.GetNuspec())
+                {
+                    nuspec = new NuspecReader(stream);
+                }
+            }
 
             var dependencySet = nuspec
                 .GetDependencyGroups()

--- a/src/NuGet.Packaging.Core/Properties/Strings.Designer.cs
+++ b/src/NuGet.Packaging.Core/Properties/Strings.Designer.cs
@@ -27,7 +27,7 @@ namespace NuGet.Packaging.Core
         }
 
         /// <summary>
-        /// Nuspec file does not exist in package '{0}'
+        /// Nuspec file does not exist in package.
         /// </summary>
         internal static string MissingNuspec
         {
@@ -35,11 +35,27 @@ namespace NuGet.Packaging.Core
         }
 
         /// <summary>
-        /// Nuspec file does not exist in package '{0}'
+        /// Nuspec file does not exist in package.
         /// </summary>
-        internal static string FormatMissingNuspec(object p0)
+        internal static string FormatMissingNuspec()
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("MissingNuspec"), p0);
+            return GetString("MissingNuspec");
+        }
+
+        /// <summary>
+        /// Package contains multiple nuspec files.
+        /// </summary>
+        internal static string MultipleNuspecFiles
+        {
+            get { return GetString("MultipleNuspecFiles"); }
+        }
+
+        /// <summary>
+        /// Package contains multiple nuspec files.
+        /// </summary>
+        internal static string FormatMultipleNuspecFiles()
+        {
+            return GetString("MultipleNuspecFiles");
         }
 
         /// <summary>

--- a/src/NuGet.Packaging.Core/Strings.resx
+++ b/src/NuGet.Packaging.Core/Strings.resx
@@ -121,7 +121,10 @@
     <value>Nuspec file does not contain the '{0}' node.</value>
   </data>
   <data name="MissingNuspec" xml:space="preserve">
-    <value>Nuspec file does not exist in package '{0}'</value>
+    <value>Nuspec file does not exist in package.</value>
+  </data>
+  <data name="MultipleNuspecFiles" xml:space="preserve">
+    <value>Package contains multiple nuspec files.</value>
   </data>
   <data name="StringCannotBeNullOrEmpty" xml:space="preserve">
     <value>String argument '{0}' cannot be null or empty</value>

--- a/src/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Packaging/PackageFolderReader.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using NuGet.Frameworks;
+using NuGet.Packaging.Core;
 
 namespace NuGet.Packaging
 {
@@ -62,14 +62,18 @@ namespace NuGet.Packaging
         /// </summary>
         public override Stream GetNuspec()
         {
-            var nuspecFile = _root.GetFiles("*.nuspec", SearchOption.TopDirectoryOnly).FirstOrDefault();
+            var nuspecFiles = _root.GetFiles("*.nuspec", SearchOption.TopDirectoryOnly);
 
-            if (nuspecFile == null)
+            if (nuspecFiles.Length == 0)
             {
-                throw new FileNotFoundException(String.Format(CultureInfo.CurrentCulture, Strings.MissingNuspec, _root.FullName));
+                throw new PackagingException(Strings.MissingNuspec);
+            }
+            else if (nuspecFiles.Length > 1)
+            {
+                throw new PackagingException(Strings.MultipleNuspecFiles);
             }
 
-            return nuspecFile.OpenRead();
+            return nuspecFiles[0].OpenRead();
         }
 
         /// <summary>
@@ -100,7 +104,6 @@ namespace NuGet.Packaging
             yield break;
         }
 
-        // TODO: add support for NuGet.ContentModel here
         protected override IEnumerable<string> GetFiles(string folder)
         {
             var searchFolder = new DirectoryInfo(Path.Combine(_root.FullName, folder));

--- a/src/NuGet.Packaging/PackageReader.cs
+++ b/src/NuGet.Packaging/PackageReader.cs
@@ -108,6 +108,26 @@ namespace NuGet.Packaging
             return stream;
         }
 
+        public override Stream GetNuspec()
+        {
+            // Find all nuspec files in the root folder of the zip.
+            var nuspecEntries = ZipArchive.Entries.Where(entry =>
+                entry.Name.Length == entry.FullName.Length
+                    && entry.Name.EndsWith(PackagingCoreConstants.NuspecExtension, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+
+            if (nuspecEntries.Length == 0)
+            {
+                throw new PackagingException(Strings.MissingNuspec);
+            }
+            else if (nuspecEntries.Length > 1)
+            {
+                throw new PackagingException(Strings.MultipleNuspecFiles);
+            }
+
+            return nuspecEntries[0].Open();
+        }
+
         /// <summary>
         /// Underlying zip archive
         /// </summary>

--- a/src/NuGet.Packaging/Properties/Strings.Designer.cs
+++ b/src/NuGet.Packaging/Properties/Strings.Designer.cs
@@ -107,7 +107,39 @@ namespace NuGet.Packaging
         }
 
         /// <summary>
-        /// Nuspec file does not exist in package '{0}'
+        /// Fail to load packages.config as XML file. Please check it. 
+        /// </summary>
+        internal static string FailToLoadPackagesConfig
+        {
+            get { return GetString("FailToLoadPackagesConfig"); }
+        }
+
+        /// <summary>
+        /// Fail to load packages.config as XML file. Please check it. 
+        /// </summary>
+        internal static string FormatFailToLoadPackagesConfig()
+        {
+            return GetString("FailToLoadPackagesConfig");
+        }
+
+        /// <summary>
+        /// MinClientVersion already exists in packages.config
+        /// </summary>
+        internal static string MinClientVersionAlreadyExist
+        {
+            get { return GetString("MinClientVersionAlreadyExist"); }
+        }
+
+        /// <summary>
+        /// MinClientVersion already exists in packages.config
+        /// </summary>
+        internal static string FormatMinClientVersionAlreadyExist()
+        {
+            return GetString("MinClientVersionAlreadyExist");
+        }
+
+        /// <summary>
+        /// Nuspec file does not exist in package.
         /// </summary>
         internal static string MissingNuspec
         {
@@ -115,11 +147,43 @@ namespace NuGet.Packaging
         }
 
         /// <summary>
-        /// Nuspec file does not exist in package '{0}'
+        /// Nuspec file does not exist in package.
         /// </summary>
-        internal static string FormatMissingNuspec(object p0)
+        internal static string FormatMissingNuspec()
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("MissingNuspec"), p0);
+            return GetString("MissingNuspec");
+        }
+
+        /// <summary>
+        /// Package entry already exists in packages.config. Id: {0}
+        /// </summary>
+        internal static string PackageEntryAlreadyExist
+        {
+            get { return GetString("PackageEntryAlreadyExist"); }
+        }
+
+        /// <summary>
+        /// Package entry already exists in packages.config. Id: {0}
+        /// </summary>
+        internal static string FormatPackageEntryAlreadyExist(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("PackageEntryAlreadyExist"), p0);
+        }
+
+        /// <summary>
+        /// Package entry does not exists in packages.config. Id: {0}, Version: {1}
+        /// </summary>
+        internal static string PackageEntryNotExist
+        {
+            get { return GetString("PackageEntryNotExist"); }
+        }
+
+        /// <summary>
+        /// Package entry does not exists in packages.config. Id: {0}, Version: {1}
+        /// </summary>
+        internal static string FormatPackageEntryNotExist(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("PackageEntryNotExist"), p0, p1);
         }
 
         /// <summary>
@@ -163,35 +227,27 @@ namespace NuGet.Packaging
         }
 
         /// <summary>
-        /// Package entry already exists in packages.config. Id: {0}
+        /// An error occurred while updating packages.config. The file was closed before the entry could be added.
         /// </summary>
-        internal static string PackageEntryAlreadyExist
+        internal static string FormatUnableToAddEntry()
         {
-            get { return GetString("PackageEntryAlreadyExist"); }
+            return GetString("UnableToAddEntry");
         }
 
         /// <summary>
-        /// Package entry does not exists in packages.config. Id: {0}, Version: {1}
+        /// Package contains multiple nuspec files.
         /// </summary>
-        internal static string PackageEntryNotExist
+        internal static string MultipleNuspecFiles
         {
-            get { return GetString("PackageEntryNotExist"); }
+            get { return GetString("MultipleNuspecFiles"); }
         }
 
         /// <summary>
-        /// MinClientVersion already exists in packages.config
+        /// Package contains multiple nuspec files.
         /// </summary>
-        internal static string MinClientVersionAlreadyExist
+        internal static string FormatMultipleNuspecFiles()
         {
-            get { return GetString("MinClientVersionAlreadyExist"); }
-        }
-
-        /// <summary>
-        /// Fail to load packages.config as XML file. Please check it. 
-        /// </summary>
-        internal static string FailToLoadPackagesConfig
-        {
-            get { return GetString("FailToLoadPackagesConfig"); }
+            return GetString("MultipleNuspecFiles");
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Packaging/Strings.resx
@@ -142,7 +142,7 @@
     <value>MinClientVersion already exists in packages.config</value>
   </data>
   <data name="MissingNuspec" xml:space="preserve">
-    <value>Nuspec file does not exist in package '{0}'</value>
+    <value>Nuspec file does not exist in package.</value>
   </data>
   <data name="PackageEntryAlreadyExist" xml:space="preserve">
     <value>Package entry already exists in packages.config. Id: {0}</value>
@@ -158,5 +158,8 @@
   </data>
   <data name="UnableToAddEntry" xml:space="preserve">
     <value>An error occurred while updating packages.config. The file was closed before the entry could be added.</value>
+  </data>
+  <data name="MultipleNuspecFiles" xml:space="preserve">
+    <value>Package contains multiple nuspec files.</value>
   </data>
 </root>

--- a/src/NuGet.Protocol.Core.v3/Properties/Strings.Designer.cs
+++ b/src/NuGet.Protocol.Core.v3/Properties/Strings.Designer.cs
@@ -331,6 +331,22 @@ namespace NuGet.Protocol.Core.v3
         }
 
         /// <summary>
+        /// The source does not have the 'version' property.
+        /// </summary>
+        internal static string Protocol_MissingVersion
+        {
+            get { return GetString("Protocol_MissingVersion"); }
+        }
+
+        /// <summary>
+        /// The source does not have the 'version' property.
+        /// </summary>
+        internal static string FormatProtocol_MissingVersion()
+        {
+            return GetString("Protocol_MissingVersion");
+        }
+
+        /// <summary>
         /// An error occurred while retrieving package metadata for '{0}' from source '{1}'.
         /// </summary>
         internal static string Protocol_PackageMetadataError
@@ -339,11 +355,11 @@ namespace NuGet.Protocol.Core.v3
         }
 
         /// <summary>
-        /// The source does not have the 'version' property.
+        /// An error occurred while retrieving package metadata for '{0}' from source '{1}'.
         /// </summary>
-        internal static string Protocol_MissingVersion
+        internal static string FormatProtocol_PackageMetadataError(object p0, object p1)
         {
-            get { return GetString("Protocol_MissingVersion"); }
+            return string.Format(CultureInfo.CurrentCulture, GetString("Protocol_PackageMetadataError"), p0, p1);
         }
 
         /// <summary>
@@ -355,11 +371,11 @@ namespace NuGet.Protocol.Core.v3
         }
 
         /// <summary>
-        /// An error occurred while retrieving package metadata for '{0}' from source '{1}'.
+        /// The source version is not supported: '{0}'.
         /// </summary>
-            internal static string FormatProtocol_PackageMetadataError(object p0, object p1)
+        internal static string FormatProtocol_UnsupportedVersion(object p0)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("Protocol_PackageMetadataError"), p0, p1);
+            return string.Format(CultureInfo.CurrentCulture, GetString("Protocol_UnsupportedVersion"), p0);
         }
 
         /// <summary>

--- a/src/NuGet.Protocol.Core.v3/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
+++ b/src/NuGet.Protocol.Core.v3/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
@@ -5,14 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.Logging;
-using NuGet.Packaging;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
@@ -89,13 +87,12 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
                 return null;
             }
 
-            using (var stream = await PackageUtilities.OpenNuspecStreamFromNupkgAsync(
+            var reader = await PackageUtilities.OpenNuspecFromNupkgAsync(
                 packageInfo.Id,
                 OpenNupkgStreamAsync(packageInfo, cancellationToken),
-                Logger))
-            {
-                return GetDependencyInfo(new NuspecReader(stream));
-            }
+                Logger);
+
+            return GetDependencyInfo(reader);
         }
 
         public override async Task<Stream> GetNupkgStreamAsync(string id, NuGetVersion version, CancellationToken cancellationToken)

--- a/src/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
+++ b/src/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
@@ -13,7 +12,6 @@ using System.Xml.Linq;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Logging;
-using NuGet.Packaging;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
@@ -83,13 +81,12 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
                 return null;
             }
 
-            using (var stream = await PackageUtilities.OpenNuspecStreamFromNupkgAsync(
+            var reader = await PackageUtilities.OpenNuspecFromNupkgAsync(
                 packageInfo.Id,
                 OpenNupkgStreamAsync(packageInfo, cancellationToken),
-                Logger))
-            {
-                return GetDependencyInfo(new NuspecReader(stream));
-            }
+                Logger);
+
+            return GetDependencyInfo(reader);
         }
 
         public override async Task<Stream> GetNupkgStreamAsync(string id, NuGetVersion version, CancellationToken cancellationToken)

--- a/src/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
+++ b/src/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
@@ -5,12 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Logging;
-using NuGet.Packaging;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
@@ -67,13 +65,12 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
                 return null;
             }
 
-            using (var stream = await PackageUtilities.OpenNuspecStreamFromNupkgAsync(
+            var reader = await PackageUtilities.OpenNuspecFromNupkgAsync(
                 packageInfo.Identity.Id,
                 OpenNupkgStreamAsync(packageInfo, cancellationToken),
-                Logger))
-            {
-                return GetDependencyInfo(new NuspecReader(stream));
-            }
+                Logger);
+
+            return GetDependencyInfo(reader);
         }
 
         public override async Task<Stream> GetNupkgStreamAsync(string id, NuGetVersion version, CancellationToken cancellationToken)

--- a/test/NuGet.Packaging.Test/PackageFolderReaderTests.cs
+++ b/test/NuGet.Packaging.Test/PackageFolderReaderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -11,31 +12,311 @@ using Xunit;
 
 namespace NuGet.Packaging.Test
 {
-    public class PackageFolderReaderTests
+    public class PackageFolderReaderTests : IDisposable
     {
+        [Fact]
+        public void PackageFolderReader_NuspecCountOne()
+        {
+            // Arrange
+            var workingDir = GetTempDir();
+
+            var stream = new MemoryStream();
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                zip.AddEntry("lib/net45/a.dll", new byte[0]);
+                zip.AddEntry("package.nuspec", new byte[5]);
+            }
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            var zipFile = new ZipArchive(stream, ZipArchiveMode.Read);
+
+            zipFile.ExtractAll(workingDir.FullName);
+
+            var folderReader = new PackageFolderReader(workingDir.FullName);
+
+            // Act
+            using (var nuspec = folderReader.GetNuspec())
+            {
+                // Assert
+                Assert.NotNull(nuspec);
+                Assert.Equal(5, nuspec.ReadAllBytes().Count());
+            }
+        }
+
+        [Fact]
+        public void PackageFolderReader_NuspecCountNested()
+        {
+            // Arrange
+            var workingDir = GetTempDir();
+
+            var stream = new MemoryStream();
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                zip.AddEntry("lib/net45/a.dll", new byte[0]);
+                zip.AddEntry("package.nuspec", new byte[5]);
+                zip.AddEntry("content/package.nuspec", new byte[0]);
+            }
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            var zipFile = new ZipArchive(stream, ZipArchiveMode.Read);
+
+            zipFile.ExtractAll(workingDir.FullName);
+
+            var folderReader = new PackageFolderReader(workingDir.FullName);
+
+            // Act
+            using (var nuspec = folderReader.GetNuspec())
+            {
+                // Assert
+                Assert.NotNull(nuspec);
+                Assert.Equal(5, nuspec.ReadAllBytes().Count());
+            }
+        }
+
+        [Fact]
+        public void PackageFolderReader_NuspecCountNestedOnly()
+        {
+            // Arrange
+            var workingDir = GetTempDir();
+
+            var stream = new MemoryStream();
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                zip.AddEntry("lib/net45/a.dll", new byte[0]);
+                zip.AddEntry("content/package.nuspec", new byte[0]);
+            }
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            var zipFile = new ZipArchive(stream, ZipArchiveMode.Read);
+
+            zipFile.ExtractAll(workingDir.FullName);
+
+            var reader = new PackageFolderReader(workingDir.FullName);
+
+            var threwPackagingException = false;
+
+            // Act
+            try
+            {
+                var nuspec = reader.GetNuspec();
+            }
+            catch (PackagingException)
+            {
+                threwPackagingException = true;
+            }
+
+            // Assert
+            Assert.True(threwPackagingException);
+        }
+
+        [Fact]
+        public void PackageFolderReader_NuspecCountMultiple()
+        {
+            // Arrange
+            var workingDir = GetTempDir();
+
+            var stream = new MemoryStream();
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                zip.AddEntry("lib/net45/a.dll", new byte[0]);
+                zip.AddEntry("package.NUSPEC", new byte[0]);
+                zip.AddEntry("package2.nuspec", new byte[0]);
+            }
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            var zipFile = new ZipArchive(stream, ZipArchiveMode.Read);
+
+            zipFile.ExtractAll(workingDir.FullName);
+
+            var reader = new PackageFolderReader(workingDir.FullName);
+
+            var threwPackagingException = false;
+
+            // Act
+            try
+            {
+                var nuspec = reader.GetNuspec();
+            }
+            catch (PackagingException)
+            {
+                threwPackagingException = true;
+            }
+
+            // Assert
+            Assert.True(threwPackagingException);
+        }
+
+        [Fact]
+        public void PackageFolderReader_NuspecCountNone()
+        {
+            // Arrange
+            var workingDir = GetTempDir();
+
+            var stream = new MemoryStream();
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                zip.AddEntry("lib/net45/a.dll", new byte[0]);
+            }
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            var zipFile = new ZipArchive(stream, ZipArchiveMode.Read);
+
+            zipFile.ExtractAll(workingDir.FullName);
+
+            var reader = new PackageFolderReader(workingDir.FullName);
+
+            var threwPackagingException = false;
+
+            // Act
+            try
+            {
+                var nuspec = reader.GetNuspec();
+            }
+            catch (PackagingException)
+            {
+                threwPackagingException = true;
+            }
+
+            // Assert
+            Assert.True(threwPackagingException);
+        }
+
+        [Fact]
+        public void PackageFolderReader_NuspecCountNoneInvalidEnding()
+        {
+            // Arrange
+            var workingDir = GetTempDir();
+
+            var stream = new MemoryStream();
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                zip.AddEntry("lib/net45/a.dll", new byte[0]);
+                zip.AddEntry("nuspec.blah", new byte[0]);
+                zip.AddEntry("blahnuspec", new byte[0]);
+                zip.AddEntry("blah/nuspec", new byte[0]);
+                zip.AddEntry("blah-nuspec", new byte[0]);
+                zip.AddEntry("blah.nuspecc", new byte[0]);
+            }
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            var zipFile = new ZipArchive(stream, ZipArchiveMode.Read);
+
+            zipFile.ExtractAll(workingDir.FullName);
+
+            var reader = new PackageFolderReader(workingDir.FullName);
+
+            var threwPackagingException = false;
+
+            // Act
+            try
+            {
+                var nuspec = reader.GetNuspec();
+            }
+            catch (PackagingException)
+            {
+                threwPackagingException = true;
+            }
+
+            // Assert
+            Assert.True(threwPackagingException);
+        }
+
+        [Fact]
+        public void PackageFolderReader_NuspecCountEscapingInName()
+        {
+            // Arrange
+            var workingDir = GetTempDir();
+
+            var stream = new MemoryStream();
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                zip.AddEntry("lib/net45/a.dll", new byte[0]);
+                zip.AddEntry("package%20.nuspec", new byte[5]);
+            }
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            var zipFile = new ZipArchive(stream, ZipArchiveMode.Read);
+
+            zipFile.ExtractAll(workingDir.FullName);
+
+            var reader = new PackageFolderReader(workingDir.FullName);
+
+            // Act
+            using (var nuspec = reader.GetNuspec())
+            {
+                // Assert
+                Assert.NotNull(nuspec);
+                Assert.Equal(5, nuspec.ReadAllBytes().Count());
+            }
+        }
+
         // verify a zip package reader, and folder package reader handle reference items the same
         [Fact]
         public void PackageFolderReader_Basic()
         {
             var packageNupkg = TestPackages.GetLegacyTestPackage();
+            _path.Add(packageNupkg.FullName);
+
             var zip = new ZipArchive(packageNupkg.OpenRead());
             PackageReader zipReader = new PackageReader(zip);
 
             var folder = Path.Combine(packageNupkg.Directory.FullName, Guid.NewGuid().ToString());
 
-            var zipFile = new ZipArchive(File.OpenRead(packageNupkg.FullName));
+            using (var zipFile = new ZipArchive(File.OpenRead(packageNupkg.FullName)))
+            {
+                zipFile.ExtractAll(folder);
 
-            zipFile.ExtractAll(folder);
+                var folderReader = new PackageFolderReader(folder);
 
-            var folderReader = new PackageFolderReader(folder);
+                Assert.Equal(zipReader.GetIdentity(), folderReader.GetIdentity(), new PackageIdentityComparer());
 
-            Assert.Equal(zipReader.GetIdentity(), folderReader.GetIdentity(), new PackageIdentityComparer());
+                Assert.Equal(zipReader.GetLibItems().Count(), folderReader.GetLibItems().Count());
 
-            Assert.Equal(zipReader.GetLibItems().Count(), folderReader.GetLibItems().Count());
+                Assert.Equal(zipReader.GetReferenceItems().Count(), folderReader.GetReferenceItems().Count());
 
-            Assert.Equal(zipReader.GetReferenceItems().Count(), folderReader.GetReferenceItems().Count());
+                Assert.Equal(zipReader.GetReferenceItems().First().Items.First(), folderReader.GetReferenceItems().First().Items.First());
+            }
+        }
 
-            Assert.Equal(zipReader.GetReferenceItems().First().Items.First(), folderReader.GetReferenceItems().First().Items.First());
+        private DirectoryInfo GetTempDir()
+        {
+            var workingDir = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + "/"));
+            workingDir.Create();
+            _path.Add(workingDir.FullName);
+
+            return workingDir;
+        }
+
+        private ConcurrentBag<string> _path = new ConcurrentBag<string>();
+
+        public void Dispose()
+        {
+            foreach (var path in _path)
+            {
+                try
+                {
+                    if (File.Exists(path))
+                    {
+                        File.Delete(path);
+                    }
+
+                    if (Directory.Exists(path))
+                    {
+                        Directory.Delete(path, true);
+                    }
+                }
+                catch
+                {
+
+                }
+            }
         }
     }
 }

--- a/test/NuGet.Packaging.Test/PackageReaderTests.cs
+++ b/test/NuGet.Packaging.Test/PackageReaderTests.cs
@@ -1,22 +1,210 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using NuGet.Frameworks;
+using NuGet.Packaging.Core;
 using NuGet.Test.Utility;
 using Xunit;
 
 namespace NuGet.Packaging.Test
 {
-    public class PackageReaderTests
+    public class PackageReaderTests : IDisposable
     {
+        [Fact]
+        public void PackageReader_NuspecCountOne()
+        {
+            // Arrange
+            var stream = new MemoryStream();
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                zip.AddEntry("lib/net45/a.dll", new byte[0]);
+                zip.AddEntry("package.nuspec", new byte[5]);
+            }
+
+            stream.Seek(0, SeekOrigin.Begin);
+            var reader = new PackageReader(stream);
+
+            // Act
+            var nuspec = reader.GetNuspec();
+
+            // Assert
+            Assert.NotNull(nuspec);
+            Assert.Equal(5, nuspec.ReadAllBytes().Count());
+        }
+
+        [Fact]
+        public void PackageReader_NuspecCountNested()
+        {
+            // Arrange
+            var stream = new MemoryStream();
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                zip.AddEntry("lib/net45/a.dll", new byte[0]);
+                zip.AddEntry("package.nuspec", new byte[5]);
+                zip.AddEntry("content/package.nuspec", new byte[0]);
+            }
+
+            var reader = new PackageReader(stream);
+
+            // Act
+            var nuspec = reader.GetNuspec();
+
+            // Assert
+            Assert.NotNull(nuspec);
+            Assert.Equal(5, nuspec.ReadAllBytes().Count());
+        }
+
+        [Fact]
+        public void PackageReader_NuspecCountNestedOnly()
+        {
+            // Arrange
+            var stream = new MemoryStream();
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                zip.AddEntry("lib/net45/a.dll", new byte[0]);
+                zip.AddEntry("content/package.nuspec", new byte[0]);
+            }
+
+            var reader = new PackageReader(stream);
+            var threwPackagingException = false;
+
+            // Act
+            try
+            {
+                var nuspec = reader.GetNuspec();
+            }
+            catch (PackagingException)
+            {
+                threwPackagingException = true;
+            }
+
+            // Assert
+            Assert.True(threwPackagingException);
+        }
+
+        [Fact]
+        public void PackageReader_NuspecCountMultiple()
+        {
+            // Arrange
+            var stream = new MemoryStream();
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                zip.AddEntry("lib/net45/a.dll", new byte[0]);
+                zip.AddEntry("package.NUSPEC", new byte[0]);
+                zip.AddEntry("package2.nuspec", new byte[0]);
+            }
+
+            var reader = new PackageReader(stream);
+            var threwPackagingException = false;
+
+            // Act
+            try
+            {
+                var nuspec = reader.GetNuspec();
+            }
+            catch (PackagingException)
+            {
+                threwPackagingException = true;
+            }
+
+            // Assert
+            Assert.True(threwPackagingException);
+        }
+
+        [Fact]
+        public void PackageReader_NuspecCountNone()
+        {
+            // Arrange
+            var stream = new MemoryStream();
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                zip.AddEntry("lib/net45/a.dll", new byte[0]);
+            }
+
+            var reader = new PackageReader(stream);
+            var threwPackagingException = false;
+
+            // Act
+            try
+            {
+                var nuspec = reader.GetNuspec();
+            }
+            catch (PackagingException)
+            {
+                threwPackagingException = true;
+            }
+
+            // Assert
+            Assert.True(threwPackagingException);
+        }
+
+        [Fact]
+        public void PackageReader_NuspecCountNoneInvalidEnding()
+        {
+            // Arrange
+            var stream = new MemoryStream();
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                zip.AddEntry("lib/net45/a.dll", new byte[0]);
+                zip.AddEntry("nuspec.blah", new byte[0]);
+                zip.AddEntry("blahnuspec", new byte[0]);
+                zip.AddEntry("blah/nuspec", new byte[0]);
+                zip.AddEntry("blah-nuspec", new byte[0]);
+                zip.AddEntry("blah.nuspecc", new byte[0]);
+            }
+
+            var reader = new PackageReader(stream);
+            var threwPackagingException = false;
+
+            // Act
+            try
+            {
+                var nuspec = reader.GetNuspec();
+            }
+            catch (PackagingException)
+            {
+                threwPackagingException = true;
+            }
+
+            // Assert
+            Assert.True(threwPackagingException);
+        }
+
+        [Fact]
+        public void PackageReader_NuspecCountEscapingInName()
+        {
+            // Arrange
+            var stream = new MemoryStream();
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                zip.AddEntry("lib/net45/a.dll", new byte[0]);
+                zip.AddEntry("package%20.nuspec", new byte[5]);
+            }
+
+            var reader = new PackageReader(stream);
+
+            // Act
+            var nuspec = reader.GetNuspec();
+
+            // Assert
+            Assert.NotNull(nuspec);
+            Assert.Equal(5, nuspec.ReadAllBytes().Count());
+        }
+
         [Fact]
         public void PackageReader_RespectReferencesAccordingToDifferentFrameworks()
         {
             // Copy of the InstallPackageRespectReferencesAccordingToDifferentFrameworks functional test
 
             // Arrange
-            var zip = TestPackages.GetZip(TestPackages.GetNearestReferenceFilteringPackage());
+            var path = TestPackages.GetNearestReferenceFilteringPackage();
+            _paths.Add(path.FullName);
+            var zip = TestPackages.GetZip(path);
             var reader = new PackageReader(zip);
 
             // Act
@@ -36,7 +224,9 @@ namespace NuGet.Packaging.Test
         public void PackageReader_LegacyFolders()
         {
             // Verify legacy folder names such as 40 and 35 parse to frameworks
-            var zip = TestPackages.GetZip(TestPackages.GetLegacyFolderPackage());
+            var path = TestPackages.GetLegacyFolderPackage();
+            _paths.Add(path.FullName);
+            var zip = TestPackages.GetZip(path);
 
             using (PackageReader reader = new PackageReader(zip))
             {
@@ -62,7 +252,9 @@ namespace NuGet.Packaging.Test
         [Fact]
         public void PackageReader_NestedReferenceItemsMixed()
         {
-            var zip = TestPackages.GetZip(TestPackages.GetLibEmptyFolderPackage());
+            var path = TestPackages.GetLibEmptyFolderPackage();
+            _paths.Add(path.FullName);
+            var zip = TestPackages.GetZip(path);
 
             using (PackageReader reader = new PackageReader(zip))
             {
@@ -89,7 +281,9 @@ namespace NuGet.Packaging.Test
         [Fact]
         public void PackageReader_EmptyLibFolder()
         {
-            var zip = TestPackages.GetZip(TestPackages.GetLibEmptyFolderPackage());
+            var path = TestPackages.GetLibEmptyFolderPackage();
+            _paths.Add(path.FullName);
+            var zip = TestPackages.GetZip(path);
 
             using (PackageReader reader = new PackageReader(zip))
             {
@@ -104,7 +298,9 @@ namespace NuGet.Packaging.Test
         [Fact]
         public void PackageReader_NestedReferenceItems()
         {
-            var zip = TestPackages.GetZip(TestPackages.GetLibSubFolderPackage());
+            var path = TestPackages.GetLibSubFolderPackage();
+            _paths.Add(path.FullName);
+            var zip = TestPackages.GetZip(path);
 
             using (PackageReader reader = new PackageReader(zip))
             {
@@ -125,7 +321,9 @@ namespace NuGet.Packaging.Test
         [InlineData("2.5-beta", "2.5.0-beta")]
         public void PackageReader_MinClientVersion(string minClientVersion, string expected)
         {
-            var zip = TestPackages.GetZip(TestPackages.GetLegacyTestPackageMinClient(minClientVersion));
+            var path = TestPackages.GetLegacyTestPackageMinClient(minClientVersion);
+            _paths.Add(path.FullName);
+            var zip = TestPackages.GetZip(path);
 
             using (PackageReader reader = new PackageReader(zip))
             {
@@ -138,7 +336,9 @@ namespace NuGet.Packaging.Test
         [Fact]
         public void PackageReader_ContentWithMixedFrameworks()
         {
-            var zip = TestPackages.GetZip(TestPackages.GetLegacyContentPackageMixed());
+            var path = TestPackages.GetLegacyContentPackageMixed();
+            _paths.Add(path.FullName);
+            var zip = TestPackages.GetZip(path);
 
             using (PackageReader reader = new PackageReader(zip))
             {
@@ -151,7 +351,9 @@ namespace NuGet.Packaging.Test
         [Fact]
         public void PackageReader_ContentWithFrameworks()
         {
-            var zip = TestPackages.GetZip(TestPackages.GetLegacyContentPackageWithFrameworks());
+            var path = TestPackages.GetLegacyContentPackageWithFrameworks();
+            _paths.Add(path.FullName);
+            var zip = TestPackages.GetZip(path);
 
             using (PackageReader reader = new PackageReader(zip))
             {
@@ -164,7 +366,9 @@ namespace NuGet.Packaging.Test
         [Fact]
         public void PackageReader_ContentNoFrameworks()
         {
-            var zip = TestPackages.GetZip(TestPackages.GetLegacyContentPackage());
+            var path = TestPackages.GetLegacyContentPackage();
+            _paths.Add(path.FullName);
+            var zip = TestPackages.GetZip(path);
 
             using (PackageReader reader = new PackageReader(zip))
             {
@@ -182,7 +386,9 @@ namespace NuGet.Packaging.Test
         [Fact]
         public void PackageReader_NoReferences()
         {
-            var zip = TestPackages.GetZip(TestPackages.GetLegacyTestPackage());
+            var path = TestPackages.GetLegacyTestPackage();
+            _paths.Add(path.FullName);
+            var zip = TestPackages.GetZip(path);
 
             using (PackageReader reader = new PackageReader(zip))
             {
@@ -198,7 +404,9 @@ namespace NuGet.Packaging.Test
         [Fact]
         public void PackageReader_ReferencesWithGroups()
         {
-            var zip = TestPackages.GetZip(TestPackages.GetLegacyTestPackageWithReferenceGroups());
+            var path = TestPackages.GetLegacyTestPackageWithReferenceGroups();
+            _paths.Add(path.FullName);
+            var zip = TestPackages.GetZip(path);
 
             using (PackageReader reader = new PackageReader(zip))
             {
@@ -220,7 +428,9 @@ namespace NuGet.Packaging.Test
         [Fact]
         public void PackageReader_ReferencesWithoutGroups()
         {
-            var zip = TestPackages.GetZip(TestPackages.GetLegacyTestPackageWithPre25References());
+            var path = TestPackages.GetLegacyTestPackageWithPre25References();
+            _paths.Add(path.FullName);
+            var zip = TestPackages.GetZip(path);
 
             using (PackageReader reader = new PackageReader(zip))
             {
@@ -245,7 +455,9 @@ namespace NuGet.Packaging.Test
         [Fact]
         public void PackageReader_SupportedFrameworks()
         {
-            var zip = TestPackages.GetZip(TestPackages.GetLegacyTestPackage());
+            var path = TestPackages.GetLegacyTestPackage();
+            _paths.Add(path.FullName);
+            var zip = TestPackages.GetZip(path);
 
             using (PackageReader reader = new PackageReader(zip))
             {
@@ -258,18 +470,29 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        //[Fact]
-        //public void PackageReader_AgnosticFramework()
-        //{
-        //    var zip = TestPackages.GetZip(TestPackages.GetLegacyContentPackage());
+        private ConcurrentBag<string> _paths = new ConcurrentBag<string>();
 
-        //    using (PackageReader reader = new PackageReader(zip))
-        //    {
-        //        string[] frameworks = reader.GetSupportedFrameworks().Select(f => f.DotNetFrameworkName).ToArray();
+        public void Dispose()
+        {
+            foreach (var path in _paths)
+            {
+                try
+                {
+                    if (File.Exists(path))
+                    {
+                        File.Delete(path);
+                    }
 
-        //        Assert.Equal("Agnostic,Version=v0.0", frameworks[0]);
-        //        Assert.Equal(frameworks.Length, 1);
-        //    }
-        //}
+                    if (Directory.Exists(path))
+                    {
+                        Directory.Delete(path, true);
+                    }
+                }
+                catch (Exception)
+                {
+                    // Ignore
+                }
+            }
+        }
     }
 }

--- a/test/NuGet.Test.Utility/TestPackages.cs
+++ b/test/NuGet.Test.Utility/TestPackages.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Globalization;
 using System.IO;
 using System.IO.Compression;


### PR DESCRIPTION
This change improves nuspec handling and makes it consistent across packages.config and project.json projects.

The nuspec will be found by checking for .nuspec files only in the root of the zip. If only one exists it will be used. If zero or multiple exist a packaging exception will be thrown. Nuspecs in sub folders will be ignored.

PackageReader now finds the nuspec directly from the zip entries instead of using the GetFiles and GetStream abstractions which caused it to loop through all entries multiple times.

OpenNuspecFromNupkgAsync will now return a NuspecReader which reads the XML directly instead of copying the entry into a memory stream before reading it as XML.

https://github.com/NuGet/Home/issues/1358

//cc @deepakaravindr @feiling @MeniZalzman @yishaigalatzer 
