### PR TITLE
Set Default RequestCachePolicy

### DIFF
--- a/src/NuGet.Protocol.Core.v3/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Protocol.Core.v3/HttpHandlerResourceV3Provider.cs
@@ -85,6 +85,11 @@ namespace NuGet.Protocol.Core.v3
 
         private class CredentialPromptWebRequestHandler : WebRequestHandler
         {
+            public CredentialPromptWebRequestHandler()
+            {
+                CachePolicy = new System.Net.Cache.RequestCachePolicy(System.Net.Cache.RequestCacheLevel.Default);
+            }
+
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 while (true)


### PR DESCRIPTION
This handler is used when available in place of
DataClient.DefaultHandler which has caching set to Default.  It makes
sense to me that this handler should have the same settings.
