### PR TITLE
Fall back to runtime-agnostic native folder if package doesn't have a runtime-specific native folder

### DIFF
--- a/src/NuGet.Client/ManagedCodeConventions.cs
+++ b/src/NuGet.Client/ManagedCodeConventions.cs
@@ -211,8 +211,16 @@ namespace NuGet.Client
             public SelectionCriteria ForRuntime(string runtimeIdentifier)
             {
                 var builder = new SelectionCriteriaBuilder(_conventions.Properties);
+                if (!string.IsNullOrEmpty(runtimeIdentifier))
+                {
+                    //  First try runtime-specific matches
+                    builder = builder
+                        .Add[PropertyNames.RuntimeIdentifier, runtimeIdentifier];
+                }
+
+                //  Then try runtime-agnostic
                 builder = builder
-                    .Add[PropertyNames.RuntimeIdentifier, runtimeIdentifier];
+                    .Add[PropertyNames.RuntimeIdentifier, null];
                 return builder.Criteria;
             }
         }


### PR DESCRIPTION
Fixes NuGet/Home#1454
