### PR TITLE
nuget.exe 3.2.1 perf improvements (part 1)

### DIFF
--- a/src/NuGet.Commands/RestoreCommand.cs
+++ b/src/NuGet.Commands/RestoreCommand.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Configuration;
 using NuGet.ContentModel;
 using NuGet.DependencyResolver;
 using NuGet.Frameworks;
@@ -868,12 +867,13 @@ namespace NuGet.Commands
                 token: token);
         }
 
-        private IRemoteDependencyProvider CreateProviderFromSource(PackageSource source, SourceCacheContext cacheContext)
+        private IRemoteDependencyProvider CreateProviderFromSource(
+            SourceRepository repository,
+            SourceCacheContext cacheContext)
         {
-            _log.LogVerbose(Strings.FormatLog_UsingSource(source.Source));
+            _log.LogVerbose(Strings.FormatLog_UsingSource(repository.PackageSource.Source));
 
-            var nugetRepository = Repository.Factory.GetCoreV3(source.Source);
-            return new SourceRepositoryDependencyProvider(nugetRepository, _log, cacheContext);
+            return new SourceRepositoryDependencyProvider(repository, _log, cacheContext);
         }
     }
 }

--- a/src/NuGet.Commands/RestoreRequest.cs
+++ b/src/NuGet.Commands/RestoreRequest.cs
@@ -8,6 +8,7 @@ using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Core.v3;
 
 namespace NuGet.Commands
 {
@@ -20,9 +21,35 @@ namespace NuGet.Commands
         { }
 
         public RestoreRequest(PackageSpec project, IEnumerable<PackageSource> sources, string packagesDirectory)
+            : this(project, packagesDirectory)
         {
+            if (sources == null)
+            {
+                throw new ArgumentNullException(nameof(sources));
+            }
+
+            Sources = sources.Select(source => Repository.Factory.GetCoreV3(source.Source)).ToList();
+        }
+
+        public RestoreRequest(PackageSpec project, IEnumerable<SourceRepository> sources, string packagesDirectory)
+            : this(project, packagesDirectory)
+        {
+            if (sources == null)
+            {
+                throw new ArgumentNullException(nameof(sources));
+            }
+
+            Sources = sources.ToList();
+        }
+
+        private RestoreRequest(PackageSpec project, string packagesDirectory)
+        {
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
             Project = project;
-            Sources = sources.ToList().AsReadOnly();
 
             ExternalProjects = new List<ExternalProjectReference>();
             CompatibilityProfiles = new HashSet<FrameworkRuntimePair>();
@@ -40,7 +67,7 @@ namespace NuGet.Commands
         /// <summary>
         /// The complete list of sources to retrieve packages from (excluding caches)
         /// </summary>
-        public IReadOnlyList<PackageSource> Sources { get; }
+        public IReadOnlyList<SourceRepository> Sources { get; }
 
         /// <summary>
         /// The directory in which to install packages

--- a/src/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -14,6 +14,7 @@ namespace NuGet.Configuration
 
         private readonly int _hashCode;
         private bool? _isHttp;
+        private bool? _isLocal;
 
         public string Name { get; private set; }
 
@@ -55,6 +56,30 @@ namespace NuGet.Configuration
                 }
 
                 return _isHttp.Value;
+            }
+        }
+
+        /// <summary>
+        /// True if the source path is file based. Unc shares are not included.
+        /// </summary>
+        public bool IsLocal
+        {
+            get
+            {
+                if (!_isLocal.HasValue)
+                {
+                    Uri uri;
+                    if (Uri.TryCreate(Source, UriKind.Absolute, out uri))
+                    {
+                        _isLocal = uri.IsFile;
+                    }
+                    else
+                    {
+                        _isLocal = false;
+                    }
+                }
+
+                return _isLocal.Value;
             }
         }
 

--- a/src/NuGet.Protocol.Core.Types/Resources/DownloadResource.cs
+++ b/src/NuGet.Protocol.Core.Types/Resources/DownloadResource.cs
@@ -19,11 +19,6 @@ namespace NuGet.Protocol.Core.Types
             ISettings settings,
             CancellationToken token);
 
-        public abstract Task<DownloadResourceResult> GetDownloadResourceResultAsync(
-            SourcePackageDependencyInfo package,
-            ISettings settings,
-            CancellationToken token);
-
         public event EventHandler<PackageProgressEventArgs> Progress;
     }
 }

--- a/src/NuGet.Protocol.Core.Types/Resources/DownloadResource.cs
+++ b/src/NuGet.Protocol.Core.Types/Resources/DownloadResource.cs
@@ -14,7 +14,15 @@ namespace NuGet.Protocol.Core.Types
     /// </summary>
     public abstract class DownloadResource : INuGetResource
     {
-        public abstract Task<DownloadResourceResult> GetDownloadResourceResultAsync(PackageIdentity identity, ISettings settings, CancellationToken token);
+        public abstract Task<DownloadResourceResult> GetDownloadResourceResultAsync(
+            PackageIdentity identity,
+            ISettings settings,
+            CancellationToken token);
+
+        public abstract Task<DownloadResourceResult> GetDownloadResourceResultAsync(
+            SourcePackageDependencyInfo package,
+            ISettings settings,
+            CancellationToken token);
 
         public event EventHandler<PackageProgressEventArgs> Progress;
     }

--- a/src/NuGet.Protocol.Core.Types/SourcePackageDependencyInfo.cs
+++ b/src/NuGet.Protocol.Core.Types/SourcePackageDependencyInfo.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using NuGet.Packaging.Core;
-using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
 namespace NuGet.Protocol.Core.Types
@@ -8,28 +9,100 @@ namespace NuGet.Protocol.Core.Types
     public class SourcePackageDependencyInfo : PackageDependencyInfo
     {
         public SourcePackageDependencyInfo(string id, NuGetVersion version, bool listed, SourceRepository source)
-            : base(id, version)
+            : this(
+                  id,
+                  version,
+                  dependencies: Enumerable.Empty<PackageDependency>(),
+                  listed: listed,
+                  source: source)
         {
-            Listed = listed;
-            Source = source;
         }
 
-        public SourcePackageDependencyInfo(PackageIdentity identity, IEnumerable<PackageDependency> dependencies, bool listed, SourceRepository source)
+        public SourcePackageDependencyInfo(
+            string id,
+            NuGetVersion version,
+            IEnumerable<PackageDependency> dependencies,
+            bool listed,
+            SourceRepository source)
+            : this(
+                  new PackageIdentity(id, version),
+                  dependencies,
+                  listed,
+                  source,
+                  downloadUri: null,
+                  packageHash: null)
+        {
+        }
+
+        public SourcePackageDependencyInfo(
+            string id,
+            NuGetVersion version,
+            IEnumerable<PackageDependency> dependencies,
+            bool listed,
+            SourceRepository source,
+            Uri downloadUri,
+            string packageHash)
+            : this(
+                  new PackageIdentity(id, version),
+                  dependencies,
+                  listed,
+                  source,
+                  downloadUri,
+                  packageHash)
+        {
+        }
+
+        public SourcePackageDependencyInfo(
+            PackageIdentity identity,
+            IEnumerable<PackageDependency> dependencies,
+            bool listed,
+            SourceRepository source)
+            : this(
+                  identity,
+                  dependencies,
+                  listed,
+                  source,
+                  downloadUri: null,
+                  packageHash: null)
+        {
+        }
+
+        public SourcePackageDependencyInfo(
+            PackageIdentity identity,
+            IEnumerable<PackageDependency> dependencies,
+            bool listed,
+            SourceRepository source,
+            Uri downloadUri,
+            string packageHash)
             : base(identity, dependencies)
         {
             Listed = listed;
             Source = source;
+            DownloadUri = downloadUri;
+            PackageHash = packageHash;
         }
 
-        public SourcePackageDependencyInfo(string id, NuGetVersion version, IEnumerable<PackageDependency> dependencies, bool listed, SourceRepository source)
-            : base(id, version, dependencies)
-        {
-            Listed = listed;
-            Source = source;
-        }
-
+        /// <summary>
+        /// True if the package is listed and shown in search.
+        /// </summary>
+        /// <remarks>This property only applies to online sources.</remarks>
         public bool Listed { get; }
 
+        /// <summary>
+        /// Source repository the dependency information was retrieved from.
+        /// </summary>
         public SourceRepository Source { get; }
+
+        /// <summary>
+        /// The HTTP, UNC, or local file URI to the package nupkg.
+        /// </summary>
+        /// <remarks>Optional</remarks>
+        public Uri DownloadUri { get; }
+
+        /// <summary>
+        /// Package hash
+        /// </summary>
+        /// <remarks>Optional</remarks>
+        public string PackageHash { get; }
     }
 }

--- a/src/NuGet.Protocol.Core.v2/DependencyInfoResourceV2.cs
+++ b/src/NuGet.Protocol.Core.v2/DependencyInfoResourceV2.cs
@@ -63,7 +63,7 @@ namespace NuGet.Protocol.Core.v2
                 try
                 {
                     // Retrieve all packages
-                    var repoPackage = V2Client.FindPackage(package.Id, legacyVersion, allowPrereleaseVersions: true, allowUnlisted: true);
+                    var repoPackage = GetSource().FindPackage(package.Id, legacyVersion, allowPrereleaseVersions: true, allowUnlisted: true);
 
                     if (repoPackage != null)
                     {
@@ -110,7 +110,7 @@ namespace NuGet.Protocol.Core.v2
             try
             {
                 // Retrieve all packages
-                var repoPackages = V2Client.FindPackagesById(packageId);
+                var repoPackages = GetSource().FindPackagesById(packageId);
 
                 // Convert from v2 to v3 types and enumerate the list to finish all server requests before returning
                 results = repoPackages.Select(p => CreateDependencyInfo(p, projectFramework)).ToList();
@@ -174,6 +174,19 @@ namespace NuGet.Protocol.Core.v2
             }
 
             return result;
+        }
+
+        private IPackageRepository GetSource()
+        {
+            var dataServiceRepo = V2Client as DataServicePackageRepository;
+
+            if (dataServiceRepo != null)
+            {
+                var sourceUri = new Uri(dataServiceRepo.Source);
+                dataServiceRepo = new DataServicePackageRepository(sourceUri);
+            }
+
+            return dataServiceRepo ?? V2Client;
         }
 
         private static NuGetFramework GetFramework(PackageDependencySet dependencySet)

--- a/src/NuGet.Protocol.Core.v2/DependencyInfoResourceV2.cs
+++ b/src/NuGet.Protocol.Core.v2/DependencyInfoResourceV2.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -149,7 +148,32 @@ namespace NuGet.Protocol.Core.v2
                 }
             }
 
-            return new SourcePackageDependencyInfo(identity, deps, PackageExtensions.IsListed(packageVersion), _source);
+            SourcePackageDependencyInfo result = null;
+
+            var dataPackage = packageVersion as DataServicePackage;
+
+            if (dataPackage != null)
+            {
+                // Online package
+                result = new SourcePackageDependencyInfo(
+                    identity,
+                    deps,
+                    PackageExtensions.IsListed(packageVersion),
+                    _source,
+                    dataPackage.DownloadUrl,
+                    dataPackage.PackageHash);
+            }
+            else
+            {
+                // Offline package
+                result = new SourcePackageDependencyInfo(
+                    identity,
+                    deps,
+                    PackageExtensions.IsListed(packageVersion),
+                    _source);
+            }
+
+            return result;
         }
 
         private static NuGetFramework GetFramework(PackageDependencySet dependencySet)

--- a/src/NuGet.Protocol.Core.v2/DownloadResourceV2.cs
+++ b/src/NuGet.Protocol.Core.v2/DownloadResourceV2.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,6 +26,87 @@ namespace NuGet.Protocol.Core.v2
             V2Client = resource.V2Client;
         }
 
+        public override async Task<DownloadResourceResult> GetDownloadResourceResultAsync(
+            SourcePackageDependencyInfo package,
+            Configuration.ISettings settings,
+            CancellationToken token)
+        {
+            if (package == null)
+            {
+                throw new ArgumentNullException(nameof(package));
+            }
+
+            return await Task.Run(async () =>
+                {
+                    var dataServiceRepo = V2Client as DataServicePackageRepository;
+                    IPackage newPackage = null;
+
+                    // Using the below code the machine cache can be used with a hash. The fallback
+                    // is to just download the package.
+                    //
+                    // If this is a SourcePackageDependencyInfo object with everything populated 
+                    // and it is from an online source, use the machine cache and download it using the
+                    // given url.
+                    // If this info is not provided fallback to the old method.
+                    if (dataServiceRepo != null
+                            && !string.IsNullOrEmpty(package.PackageHash)
+                            && package.DownloadUri != null)
+                    {
+                        var version = SemanticVersion.Parse(package.Version.ToString());
+                        var cacheRepository = MachineCache.Default;
+
+                        try
+                        {
+                            try
+                            {
+                                // Try finding the package in the machine cache
+                                var localPackage = cacheRepository.FindPackage(package.Id, version)
+                                    as OptimizedZipPackage;
+
+                                // Validate the package matches the hash
+                                if (localPackage != null
+                                    && localPackage.IsValid
+                                    && MatchPackageHash(localPackage, package.PackageHash))
+                                {
+                                    newPackage = localPackage;
+                                }
+                            }
+                            catch
+                            {
+                                // Ignore cache failures here to match NuGet.Core
+                                // The bad package will be deleted and replaced during the download.
+                            }
+
+                            // If the local package does not exist in the cache download it from the source
+                            if (newPackage == null)
+                            {
+                                newPackage = DownloadToMachineCache(
+                                    cacheRepository, 
+                                    package, 
+                                    dataServiceRepo, 
+                                    package.DownloadUri,
+                                    token);
+                            }
+
+                            // Read the package from the machine cache
+                            if (newPackage != null)
+                            {
+                                return new DownloadResourceResult(newPackage.GetStream());
+                            }
+
+                            return null;
+                        }
+                        catch (Exception ex)
+                        {
+                            throw new NuGetProtocolException(Strings.FormatProtocol_FailedToDownloadPackage(package, V2Client.Source), ex);
+                        }
+                    }
+
+                    // package did not contain the needed info, fall back to looking up the package
+                    return await GetDownloadResourceResultAsync(package, settings, token);
+                });
+        }
+
         public override Task<DownloadResourceResult> GetDownloadResourceResultAsync(PackageIdentity identity,
             Configuration.ISettings settings,
             CancellationToken token)
@@ -38,24 +120,55 @@ namespace NuGet.Protocol.Core.v2
 
             return Task.Run(() =>
             {
+                token.ThrowIfCancellationRequested();
+
                 var version = SemanticVersion.Parse(identity.Version.ToString());
+
                 try
                 {
                     var package = V2Client.FindPackage(identity.Id, version);
 
+                    token.ThrowIfCancellationRequested();
+
                     if (package != null)
                     {
-                        if (V2Client is UnzippedPackageRepository)
+                        var dataServicePackage = package as DataServicePackage;
+                        var dataServiceRepo = V2Client as DataServicePackageRepository;
+
+                        if (dataServicePackage != null && dataServiceRepo != null)
                         {
-                            var packagePath = Path.Combine(V2Client.Source, identity.Id + "." + version);
-                            var directoryInfo = new DirectoryInfo(packagePath);
-                            if (directoryInfo.Exists)
+                            // For online sources get the url and retrieve it with cancel support
+                            var url = dataServicePackage.DownloadUrl;
+
+                            var downloadedPackage = DownloadToMachineCache(
+                                MachineCache.Default,
+                                identity,
+                                dataServiceRepo,
+                                url,
+                                token);
+
+                            if (downloadedPackage != null)
                             {
-                                return new DownloadResourceResult(package.GetStream(), new PackageFolderReader(directoryInfo));
+                                return new DownloadResourceResult(downloadedPackage.GetStream());
                             }
                         }
+                        else
+                        {
+                            // Use a folder reader for unzipped repos
+                            if (V2Client is UnzippedPackageRepository)
+                            {
+                                var packagePath = Path.Combine(V2Client.Source, identity.Id + "." + version);
+                                var directoryInfo = new DirectoryInfo(packagePath);
+                                if (directoryInfo.Exists)
+                                {
+                                    return new DownloadResourceResult(
+                                        package.GetStream(),
+                                        new PackageFolderReader(directoryInfo));
+                                }
+                            }
 
-                        return new DownloadResourceResult(package.GetStream());
+                            return new DownloadResourceResult(package.GetStream());
+                        }
                     }
 
                     return null;
@@ -65,6 +178,97 @@ namespace NuGet.Protocol.Core.v2
                     throw new NuGetProtocolException(Strings.FormatProtocol_FailedToDownloadPackage(identity, V2Client.Source), ex);
                 }
             });
+        }
+
+        /// <summary>
+        /// True if the given package matches hash
+        /// </summary>
+        private bool MatchPackageHash(IPackage package, string hash)
+        {
+            var hashProvider = new CryptoHashProvider("SHA512");
+
+            return package != null && package.GetHash(hashProvider).Equals(hash, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private IPackage DownloadToMachineCache(
+            IPackageCacheRepository cacheRepository,
+            PackageIdentity package,
+            DataServicePackageRepository dataServiceRepo,
+            Uri downloadUri,
+            CancellationToken token)
+        {
+            var packageName = new PackageNameWrapper(package);
+            var version = SemanticVersion.Parse(package.Version.ToString());
+            IPackage newPackage = null;
+
+            FileInfo tmpFile = null;
+
+            var downloadClient = new HttpClient(downloadUri)
+            {
+                UserAgent = UserAgent.UserAgentString
+            };
+
+            EventHandler<ProgressEventArgs> progressHandler = (sender, progress) =>
+            {
+                // Throw if this was canceled. This will stop the download.
+                token.ThrowIfCancellationRequested();
+            };
+
+            Action<Stream> downloadAction = (stream) =>
+            {
+                try
+                {
+                    dataServiceRepo.PackageDownloader.ProgressAvailable += progressHandler;
+                    dataServiceRepo.PackageDownloader.DownloadPackage(downloadClient, packageName, stream);
+                }
+                catch (OperationCanceledException)
+                {
+                    // The task was canceled. To avoid writing a partial file to the machine cache 
+                    // we need to clear out the current tmp file stream so that it will be ignored.
+                    stream.SetLength(0);
+
+                    // If the machine cache is using the physical file system we can find the 
+                    // path of temp file and clean it up. Otherwise NuGet.Core will just leave the temp file.
+                    var fileStream = stream as FileStream;
+                    if (fileStream != null)
+                    {
+                        tmpFile = new FileInfo(fileStream.Name);
+                    }
+                }
+                finally
+                {
+                    dataServiceRepo.PackageDownloader.ProgressAvailable -= progressHandler;
+                }
+            };
+
+            // We either do not have a package available locally or they are invalid.
+            // Download the package from the server.
+            if (cacheRepository.InvokeOnPackage(package.Id, version,
+                (stream) => downloadAction(stream)))
+            {
+                if (!token.IsCancellationRequested)
+                {
+                    newPackage = cacheRepository.FindPackage(package.Id, version);
+                    Debug.Assert(newPackage != null);
+                }
+            }
+
+            // After the stream is no longer in use, delete the tmp file if it still exists after a canceled task
+            // NuGet.Core does not properly clean these up since it does not have cancel support.
+            if (tmpFile != null && token.IsCancellationRequested && tmpFile.Exists)
+            {
+                try
+                {
+                    tmpFile.Delete();
+                }
+                catch
+                {
+                    // Ignore exceptions
+                    Debug.Fail("Unable to remove tmp file from v2 download");
+                }
+            }
+
+            return newPackage;
         }
     }
 }

--- a/src/NuGet.Protocol.Core.v2/PackageNameWrapper.cs
+++ b/src/NuGet.Protocol.Core.v2/PackageNameWrapper.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using NuGet.Packaging.Core;
+
+namespace NuGet.Protocol.Core.v2
+{
+    /// <summary>
+    /// A simple wrapper used to pass a package identity in a legacy IPackageMetadata.
+    /// </summary>
+    public class PackageNameWrapper : IPackageMetadata
+    {
+        private readonly PackageIdentity _identity;
+
+        public PackageNameWrapper(PackageIdentity identity)
+        {
+            _identity = identity;
+        }
+
+        public SemanticVersion Version
+        {
+            get
+            {
+                return SemanticVersion.Parse(_identity.Version.ToString());
+            }
+        }
+
+        public string Id
+        {
+            get
+            {
+                return _identity.Id;
+            }
+        }
+
+        #region unused
+
+        public IEnumerable<string> Authors
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public string Copyright
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public IEnumerable<PackageDependencySet> DependencySets
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public string Description
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool DevelopmentDependency
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public IEnumerable<FrameworkAssemblyReference> FrameworkAssemblies
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public Uri IconUrl
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public string Language
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public Uri LicenseUrl
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public Version MinClientVersion
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public IEnumerable<string> Owners
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public ICollection<PackageReferenceSet> PackageAssemblyReferences
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public Uri ProjectUrl
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public string ReleaseNotes
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool RequireLicenseAcceptance
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public string Summary
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public string Tags
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public string Title
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/NuGet.Protocol.Core.v2/PackageNameWrapper.cs
+++ b/src/NuGet.Protocol.Core.v2/PackageNameWrapper.cs
@@ -7,7 +7,7 @@ namespace NuGet.Protocol.Core.v2
     /// <summary>
     /// A simple wrapper used to pass a package identity in a legacy IPackageMetadata.
     /// </summary>
-    public class PackageNameWrapper : IPackageMetadata
+    internal class PackageNameWrapper : IPackageMetadata
     {
         private readonly PackageIdentity _identity;
 

--- a/src/NuGet.Protocol.Core.v2/project.json
+++ b/src/NuGet.Protocol.Core.v2/project.json
@@ -27,7 +27,8 @@
     "net45": {
       "frameworkAssemblies": {
         "System.Collections.Concurrent": "",
-        "System.Runtime.Serialization": ""
+        "System.Runtime.Serialization": "",
+        "WindowsBase": ""
       }
     }
   }

--- a/src/NuGet.Protocol.Core.v3/Constants.cs
+++ b/src/NuGet.Protocol.Core.v3/Constants.cs
@@ -21,6 +21,7 @@ namespace NuGet.Protocol.Core.v3
     {
         public static readonly string VersionV2 = "/2.0.0";
         public static readonly string TypeVersion = "/3.0.0-beta";
+        public static readonly string Version300 = "/3.0.0";
 
         public static readonly string SearchQueryService = "SearchQueryService" + TypeVersion;
         public static readonly string SearchAutocompleteService = "SearchAutocompleteService" + TypeVersion;
@@ -31,6 +32,7 @@ namespace NuGet.Protocol.Core.v3
         public static readonly string Stats = "Stats" + TypeVersion;
         public static readonly string LegacyGallery = "LegacyGallery" + VersionV2;
         public static readonly string PackagePublish = "PackagePublish" + VersionV2;
+        public static readonly string PackageBaseAddress = "PackageBaseAddress" + Version300;
     }
 
     public static class Properties

--- a/src/NuGet.Protocol.Core.v3/DependencyInfoResourceV3.cs
+++ b/src/NuGet.Protocol.Core.v3/DependencyInfoResourceV3.cs
@@ -2,15 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
-using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
@@ -167,12 +164,22 @@ namespace NuGet.Protocol.Core.v3
         /// <summary>
         /// Retrieve dependency info from a registration blob
         /// </summary>
-        private IEnumerable<SourcePackageDependencyInfo> GetPackagesFromRegistration(RegistrationInfo registration, CancellationToken token)
+        private IEnumerable<SourcePackageDependencyInfo> GetPackagesFromRegistration(
+            RegistrationInfo registration,
+            CancellationToken token)
         {
             foreach (var pkgInfo in registration.Packages)
             {
                 var dependencies = pkgInfo.Dependencies.Select(dep => new PackageDependency(dep.Id, dep.Range));
-                yield return new SourcePackageDependencyInfo(registration.Id, pkgInfo.Version, dependencies, pkgInfo.Listed, _source);
+
+                yield return new SourcePackageDependencyInfo(
+                    registration.Id,
+                    pkgInfo.Version,
+                    dependencies,
+                    pkgInfo.Listed,
+                    _source,
+                    pkgInfo.PackageContent,
+                    packageHash: null);
             }
 
             yield break;

--- a/src/NuGet.Protocol.Core.v3/ServiceIndexResourceV3Provider.cs
+++ b/src/NuGet.Protocol.Core.v3/ServiceIndexResourceV3Provider.cs
@@ -56,34 +56,41 @@ namespace NuGet.Protocol.Core.v3
 
                 using (var client = new DataClient(messageHandlerResource))
                 {
-                    var response = await client.GetAsync(uri, token);
-
-                    if (response.IsSuccessStatusCode)
+                    try
                     {
-                        if (HttpHandlerResourceV3.CredentialsSuccessfullyUsed != null && credentials != null)
-                        {
-                            HttpHandlerResourceV3.CredentialsSuccessfullyUsed(uri, credentials);
-                        }
+                        var response = await client.GetAsync(uri, token);
 
-                        var text = await response.Content.ReadAsStringAsync();
-                        return JObject.Parse(text);
-                    }
-                    else if (response.StatusCode == HttpStatusCode.Unauthorized)
-                    {
-                        credentials = null;
-                        if (HttpHandlerResourceV3.PromptForCredentials != null)
+                        if (response.IsSuccessStatusCode)
                         {
-                            credentials = HttpHandlerResourceV3.PromptForCredentials(uri);
-                        }
+                            if (HttpHandlerResourceV3.CredentialsSuccessfullyUsed != null && credentials != null)
+                            {
+                                HttpHandlerResourceV3.CredentialsSuccessfullyUsed(uri, credentials);
+                            }
 
-                        if (credentials == null)
+                            var text = await response.Content.ReadAsStringAsync();
+                            return JObject.Parse(text);
+                        }
+                        else if (response.StatusCode == HttpStatusCode.Unauthorized)
+                        {
+                            credentials = null;
+                            if (HttpHandlerResourceV3.PromptForCredentials != null)
+                            {
+                                credentials = HttpHandlerResourceV3.PromptForCredentials(uri);
+                            }
+
+                            if (credentials == null)
+                            {
+                                response.EnsureSuccessStatusCode();
+                            }
+                        }
+                        else
                         {
                             response.EnsureSuccessStatusCode();
                         }
                     }
-                    else
+                    catch (Exception)
                     {
-                        response.EnsureSuccessStatusCode();
+                        throw;
                     }
                 }
             }

--- a/src/NuGet.Protocol.Core.v3/ServiceIndexResourceV3Provider.cs
+++ b/src/NuGet.Protocol.Core.v3/ServiceIndexResourceV3Provider.cs
@@ -24,6 +24,7 @@ namespace NuGet.Protocol.Core.v3
     {
         private static readonly TimeSpan _defaultCacheDuration = TimeSpan.FromMinutes(40);
         protected readonly ConcurrentDictionary<string, ServiceIndexCacheInfo> _cache;
+        private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
 
         /// <summary>
         /// Maximum amount of time to store index.json
@@ -91,6 +92,7 @@ namespace NuGet.Protocol.Core.v3
         public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
         {
             ServiceIndexResourceV3 index = null;
+            ServiceIndexCacheInfo cacheInfo = null;
             var url = source.PackageSource.Source;
 
             // the file type can easily rule out if we need to request the url
@@ -101,53 +103,74 @@ namespace NuGet.Protocol.Core.v3
                 var utcNow = DateTime.UtcNow;
                 var entryValidCutoff = utcNow.Subtract(MaxCacheDuration);
 
-                ServiceIndexCacheInfo cacheInfo;
                 // check the cache before downloading the file
                 if (!_cache.TryGetValue(url, out cacheInfo) ||
                     entryValidCutoff > cacheInfo.CachedTime)
                 {
-                    var json = await GetIndexJson(source, token);
-
-                    // Use SemVer instead of NuGetVersion, the service index should always be
-                    // in strict SemVer format                    
-                    JToken versionToken;
-                    if (json.TryGetValue("version", out versionToken) &&
-                        versionToken.Type == JTokenType.String)
+                    // Track if the semaphore needs to be released
+                    var release = false;
+                    try
                     {
-                        SemanticVersion version;
-                        if (SemanticVersion.TryParse((string)versionToken, out version) &&
-                            version.Major == 3)
+                        // wait up to a minute for the lock, if we cannot get it just retrieve the file again.
+                        release = await _semaphore.WaitAsync(TimeSpan.FromMinutes(1), token);
+                        token.ThrowIfCancellationRequested();
+
+                        // check the cache again, another thread may have finished this one waited for the lock
+                        if (!_cache.TryGetValue(url, out cacheInfo) ||
+                            entryValidCutoff > cacheInfo.CachedTime)
                         {
-                            index = new ServiceIndexResourceV3(json, utcNow);
-                        }
-                        else
-                        {
-                            string errorMessage = string.Format(
-                                CultureInfo.CurrentCulture,
-                                Strings.Protocol_UnsupportedVersion,
-                                (string)versionToken);
-                            throw new NuGetProtocolException(errorMessage);
+                            var json = await GetIndexJson(source, token);
+
+                            // Use SemVer instead of NuGetVersion, the service index should always be
+                            // in strict SemVer format                    
+                            JToken versionToken;
+                            if (json.TryGetValue("version", out versionToken) &&
+                                versionToken.Type == JTokenType.String)
+                            {
+                                SemanticVersion version;
+                                if (SemanticVersion.TryParse((string)versionToken, out version) &&
+                                    version.Major == 3)
+                                {
+                                    index = new ServiceIndexResourceV3(json, utcNow);
+                                }
+                                else
+                                {
+                                    string errorMessage = string.Format(
+                                        CultureInfo.CurrentCulture,
+                                        Strings.Protocol_UnsupportedVersion,
+                                        (string)versionToken);
+                                    throw new NuGetProtocolException(errorMessage);
+                                }
+                            }
+                            else
+                            {
+                                throw new NuGetProtocolException(Strings.Protocol_MissingVersion);
+                            }
+
+                            // cache the value even if it is null to avoid checking it again later
+                            var cacheEntry = new ServiceIndexCacheInfo
+                            {
+                                CachedTime = utcNow,
+                                Index = index
+                            };
+
+                            // If the cache entry has expired it will already exist
+                            _cache.AddOrUpdate(url, cacheEntry, (key, value) => cacheEntry);
                         }
                     }
-                    else
+                    finally
                     {
-                        throw new NuGetProtocolException(Strings.Protocol_MissingVersion);
+                        if (release)
+                        {
+                            _semaphore.Release();
+                        }
                     }
                 }
-                else
-                {
-                    index = cacheInfo.Index;
-                }
+            }
 
-                // cache the value even if it is null to avoid checking it again later
-                var cacheEntry = new ServiceIndexCacheInfo
-                {
-                    CachedTime = utcNow,
-                    Index = index
-                };
-
-                // If the cache entry has expired it will already exist
-                _cache.AddOrUpdate(url, cacheEntry, (key, value) => cacheEntry);
+            if (index == null && cacheInfo != null)
+            {
+                index = cacheInfo.Index;
             }
 
             return new Tuple<bool, INuGetResource>(index != null, index);


### PR DESCRIPTION
Perf improvements for the v2 and v3 protocol. V3 constructs urls, V2 makes use of IHttpClient directly for fine grained control over the download.
- Fixed a major threading issue with V2 online downloads. IPackage instances depend on the context of the repository they came from and this is not thread safe in NuGet.Core. When multiple packages were downloaded from V2 at the same time a race case could occur. The fix for this is to create a new repo for each operation. For simple downloads this does not cause extra calls.  https://github.com/NuGet/Home/issues/1448
- V2 downloads can now be canceled. Previously a download would run to completion on an abandoned thread and tie up resources.
- Added download url and package hash to SourcePackageDependencyInfo to avoid going back for the data again when the package is downloaded/installed. https://github.com/NuGet/Home/issues/1426
- DownloadResourceV2 now creates an IHttpClient directly and downloads the package.
- V2 downloads will now set the correct user agent.
- Download resources will use the stored download url for a package if it exists instead of looking the package up again against v2, or finding it a second time in the registration blobs.
- V3 downloads will construct the url for the flat container download if the index.json file contains a flat container resource. This allows direct downloads and avoids an extra lookup in the registration blob.
