### PR TITLE
PackagesConfigReader support for duplicate package id entries (part 1)

### DIFF
--- a/src/NuGet.Packaging/PackagesConfigReader.cs
+++ b/src/NuGet.Packaging/PackagesConfigReader.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Xml.Linq;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
@@ -122,10 +123,20 @@ namespace NuGet.Packaging
         }
 
         /// <summary>
-        /// Reads all package node entries in the config
+        /// Reads all package node entries in the config.
+        /// If duplicate package ids exist an exception will be thrown.
         /// </summary>
-        /// <returns></returns>
         public IEnumerable<PackageReference> GetPackages()
+        {
+            return GetPackages(allowDuplicatePackageIds: false);
+        }
+
+        /// <summary>
+        /// Reads all package node entries in the config.
+        /// </summary>
+        /// <param name="allowDuplicatePackageIds">If True validation will be performed to ensure that 
+        /// only one entry exists for each unique package id.</param>
+        public IEnumerable<PackageReference> GetPackages(bool allowDuplicatePackageIds)
         {
             var packages = new List<PackageReference>();
 
@@ -191,18 +202,25 @@ namespace NuGet.Packaging
             }
 
             // check if there are duplicate entries
-            var packageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            var duplicates = new List<string>();
-            foreach (var package in packages)
+            IReadOnlyList<string> duplicates = null;
+
+            if (allowDuplicatePackageIds)
             {
-                if (packageIds.Contains(package.PackageIdentity.Id))
-                {
-                    duplicates.Add(package.PackageIdentity.Id);
-                }
-                else
-                {
-                    packageIds.Add(package.PackageIdentity.Id);
-                }
+                // Verify that no duplicate package identities
+                duplicates = packages.GroupBy(package => package.PackageIdentity, PackageIdentity.Comparer)
+                    .Where(group => group.Count() > 1)
+                    .Select(group => group.Key.ToString())
+                    .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+            }
+            else
+            {
+                // Verify no duplicate ids (this also ensures identities)
+                duplicates = packages.GroupBy(package => package.PackageIdentity.Id, StringComparer.OrdinalIgnoreCase)
+                    .Where(group => group.Count() > 1)
+                    .Select(group => group.Key.ToString())
+                    .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
             }
 
             if (duplicates.Count > 0)


### PR DESCRIPTION
This change adds a flag on GetPackages to allow the packages.config reader to return entries with duplicate package ids for the solution level package restore scenario.

Package versions will always be verified, if two identical packages exist in packages.config an exception will be thrown.

By default duplicate ids are not allowed, this flag will only be set in the command line. When the vsix supports solution level packages again it will be used there also for the solution level config.

//cc @danliu @feiling @deepakaravindr @yishaigalatzer 
