### PR TITLE
Support random combinations of NuGet.config file names to support DNX

### DIFF
--- a/src/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -13,7 +13,6 @@ namespace NuGet.Configuration
     public class PackageSourceProvider : IPackageSourceProvider
     {
         private const int MaxSupportedProtocolVersion = 3;
-        private static Lazy<bool> _isMono = new Lazy<bool>(() => Type.GetType("Mono.Runtime") != null);
 
         private ISettings Settings { get; set; }
         private readonly IEnumerable<PackageSource> _providerDefaultPrimarySources;
@@ -84,7 +83,7 @@ namespace NuGet.Configuration
         {
 #if !DNXCORE50
             // Global default NuGet source doesn't make sense on Mono
-            if (_isMono.Value)
+            if (RuntimeEnvironmentHelper.IsMono)
             {
                 return Enumerable.Empty<PackageSource>();
             }

--- a/src/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Configuration/Settings/Settings.cs
@@ -23,6 +23,19 @@ namespace NuGet.Configuration
         /// </summary>
         public static readonly string DefaultSettingsFileName = "NuGet.Config";
 
+        /// <summary>
+        /// NuGet config names with casing ordered by precedence.
+        /// </summary>
+        public static readonly string[] OrderedSettingsFileNames = 
+            RuntimeEnvironmentHelper.IsWindows ? 
+            new[] { DefaultSettingsFileName } :
+            new[]
+            {
+                "nuget.config", // preferred style
+                "NuGet.config", // Alternative
+                DefaultSettingsFileName  // NuGet v2 style
+            };
+
         private XDocument ConfigXDocument { get; set; }
         private string ConfigFileName { get; set; }
         private bool IsMachineWideSettings { get; set; }
@@ -898,12 +911,34 @@ namespace NuGet.Configuration
             // otherwise we'd end up creating them.
             foreach (var dir in GetSettingsFilePaths(root))
             {
-                var fileName = Path.Combine(dir, DefaultSettingsFileName);
-                if (FileSystemUtility.DoesFileExistIn(root, fileName))
+                var fileName = GetSettingsFileNameFromDir(dir);
+                if (fileName != null)
                 {
                     yield return fileName;
                 }
             }
+
+            yield break;
+        }
+
+        /// <summary>
+        /// Checks for each possible casing of nuget.config in the directory. The first match is
+        /// returned. If there are no nuget.config files null is returned.
+        /// </summary>
+        /// <remarks>For windows <see cref="OrderedSettingsFileNames"/> contains a single casing since
+        /// the file system is case insensitive.</remarks>
+        private static string GetSettingsFileNameFromDir(string directory)
+        {
+            foreach (var nugetConfigCasing in OrderedSettingsFileNames)
+            {
+                var file = Path.Combine(directory, nugetConfigCasing);
+                if (File.Exists(file))
+                {
+                    return file;
+                }
+            }
+
+            return null;
         }
 
         private static IEnumerable<string> GetSettingsFilePaths(string root)
@@ -913,6 +948,8 @@ namespace NuGet.Configuration
                 yield return root;
                 root = Path.GetDirectoryName(root);
             }
+
+            yield break;
         }
 
         private void Save()

--- a/src/NuGet.Configuration/Utility/RuntimeEnvironmentHelper.cs
+++ b/src/NuGet.Configuration/Utility/RuntimeEnvironmentHelper.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.IO;
+
+namespace NuGet.Configuration
+{
+    internal static class RuntimeEnvironmentHelper
+    {
+        private static Lazy<bool> _isMono = new Lazy<bool>(() => Type.GetType("Mono.Runtime") != null);
+
+        // Checking the OS environment variable is most complete way to check this on dnxcore currently.
+        private static Lazy<bool> _isWindows = new Lazy<bool>(() => 
+            Environment.GetEnvironmentVariable("OS")?.Equals("WINDOWS_NT") ?? false);
+
+        public static bool IsWindows
+        {
+            get { return _isWindows.Value; }
+        }
+
+        public static bool IsMono
+        {
+            get { return _isMono.Value; }
+        }
+    }
+}


### PR DESCRIPTION
Adding support for alternative nuget.config casings. On non-windows machines directories will be checked for all three casings instead of just "NuGet.Config", on windows there should be no change.

Based on:
https://github.com/aspnet/dnx/commit/9dca281a9594eec292c0bb502e31535900a23223

https://github.com/NuGet/Home/issues/1427

//cc @pranavkm @yishaigalatzer @deepakaravindr @zhili1208 @MeniZalzman 
